### PR TITLE
Feature/zarr shallow storage

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
         # Install ZeroC Ice from Glencoe prebuilt binaries
         python -m pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl
         python -m pip install "biomero-schema @ git+https://github.com/NL-BioImaging/biomero-schema.git@feature/zarr-shallow-storage"
-        python -m pip install --editable .[test]
+        python -m pip install --editable .[test,identity]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,7 @@ jobs:
         python -m pip install flake8 pytest pytest-cov
         # Install ZeroC Ice from Glencoe prebuilt binaries
         python -m pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl
+        python -m pip install "biomero-schema @ git+https://github.com/NL-BioImaging/biomero-schema.git@feature/zarr-shallow-storage"
         python -m pip install --editable .[test]
     - name: Lint with flake8
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,9 +110,9 @@ COPY . /auto-importer
 # Install the package - use git version if available, otherwise use fallback version
 RUN if [ -d "/auto-importer/.git" ]; then \
         git config --global --add safe.directory /auto-importer && \
-        pip install /auto-importer; \
+        pip install '/auto-importer[identity]'; \
     else \
-        SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 pip install /auto-importer; \
+        SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 pip install '/auto-importer[identity]'; \
     fi
 
 # Make the logs directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Start from the Miniconda base image to use Conda
 FROM continuumio/miniconda3:25.3.1-1
 
+ARG BIOMERO_SCHEMA_BRANCH=feature/zarr-shallow-storage
+ARG BIOMERO_SCHEMA_COMMIT=aa330bd
+
 # Set the working directory in the container
 WORKDIR /auto-importer
 
@@ -27,6 +30,12 @@ RUN apt-get update && apt-get install -y \
     fuse-overlayfs \
     podman \
     unzip
+
+# Install the shared cross-service contracts from the matching feature branch.
+# The commit URL invalidates this layer when the pinned branch head advances.
+ADD "https://api.github.com/repos/NL-BioImaging/biomero-schema/commits/${BIOMERO_SCHEMA_COMMIT}" /latest_commit_biomero_schema
+RUN pip install \
+    "biomero-schema @ git+https://github.com/NL-BioImaging/biomero-schema.git@${BIOMERO_SCHEMA_BRANCH}"
 
 # Create a group and user with specified GID and UID
 RUN groupadd -g 1000 autoimportgroup && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 FROM continuumio/miniconda3:25.3.1-1
 
 ARG BIOMERO_SCHEMA_BRANCH=feature/zarr-shallow-storage
-ARG BIOMERO_SCHEMA_COMMIT=aa330bd
 
 # Set the working directory in the container
 WORKDIR /auto-importer
@@ -32,8 +31,8 @@ RUN apt-get update && apt-get install -y \
     unzip
 
 # Install the shared cross-service contracts from the matching feature branch.
-# The commit URL invalidates this layer when the pinned branch head advances.
-ADD "https://api.github.com/repos/NL-BioImaging/biomero-schema/commits/${BIOMERO_SCHEMA_COMMIT}" /latest_commit_biomero_schema
+# The branch-head response invalidates this layer whenever the branch advances.
+ADD "https://api.github.com/repos/NL-BioImaging/biomero-schema/commits/${BIOMERO_SCHEMA_BRANCH}" /latest_commit_biomero_schema
 RUN pip install \
     "biomero-schema @ git+https://github.com/NL-BioImaging/biomero-schema.git@${BIOMERO_SCHEMA_BRANCH}"
 

--- a/README.md
+++ b/README.md
@@ -94,10 +94,15 @@ The system uses these environment variables:
 - `OMERO_PORT`: OMERO server port
 - `PODMAN_USERNS_MODE`: Set to "keep-id" for Linux user namespace mapping in preprocessing
 - `USE_REGISTER_ZARR`: Set to "true" to enable zarr register script - requires omero-zarr-pixel-buffer (overrides config file setting)
+- `BIOMERO_SHALLOW_ZARR`: Opt in to the native `biomero.shallow-zarr`
+  lifecycle operation. Existing orders are unchanged when false or absent.
+- `BIOMERO_SHALLOW_ZARR_WORKERS`: Bounded ISCC-BIO identity workers used by
+  the importer service (default `1`). This is deployment configuration, not a
+  client-controlled import option.
 
 ## Creating Upload Orders
 
-Upload orders are typically created through a user interface, such as the OMERO.biomero plugin (Importer tab) at `/omero_biomero/biomero/`, an OMERO.web extension. However, orders can also be created programmatically using the database API. 
+Upload orders are typically created through a user interface, such as the OMERO.biomero plugin (Importer tab) at `/omero_biomero/biomero/`, an OMERO.web extension. However, orders can also be created programmatically. New integrations should call `biomero_importer.submit_import_order(order)` and inspect `biomero_importer.get_importer_capabilities()` before requesting an optional lifecycle operation. The API validates and writes the same append-only database order used by existing clients; direct legacy database writers remain supported.
 
 You can use the provided test scripts shown below as examples. 
 You can also configure some more settings for them: 
@@ -112,6 +117,19 @@ sample_parent_type: "Dataset"  # or "Screen"
 ```
 
 ### BIOMERO shallow Plate registration
+
+Native importer lifecycle operations are carried in the versioned
+`ImportOptionsEnvelope` from `biomero-schema`. They execute after any existing
+container preprocessing and before OMERO registration. This means a direct
+Zarr or a Zarr produced by the existing converter can request the same
+post-processing behavior. The lifecycle engine returns a registration plan and
+does not depend on `register.py`; a future OMERO CLI Zarr importer can consume
+the same plan.
+
+Empty options and the earlier flat schema-1 registration options are upcast to
+an envelope with no operations, so they continue through the established
+import path. `imports_preprocessing` remains the legacy external-container
+contract and is not repurposed for native operations.
 
 BIOMERO workflow result orders may include an `ImportOptions` object defined by
 `biomero-schema`. For a managed shallow Plate, the default
@@ -691,4 +709,3 @@ py -3.12 -m venv .venv
 ## LICENSE
 
 License changed to GPL-2.0 (starting version 1.3), as this work depends on `omero-py` and `ezomero` libraries for the OMERO import and session management.
-

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The system uses two main tables:
 - Stores all import orders and their progress
 - Tracks stages: "Import Pending" → "Import Started" → "Import Completed"/"Import Failed"
 - Includes full metadata: user, group, destination, files, timestamps
+- Stores optional Zarr registration choices in the nullable `import_options`
+  JSON text column. Existing orders without it behave exactly as before.
 
 ### `imports_preprocessing` 
 - Stores preprocessing configuration for containerized workflows
@@ -108,6 +110,22 @@ sample_user: "researcher"
 sample_parent_id: "151"
 sample_parent_type: "Dataset"  # or "Screen"
 ```
+
+### BIOMERO shallow Plate registration
+
+BIOMERO workflow result orders may include an `ImportOptions` object defined by
+`biomero-schema`. For a managed shallow Plate, the default
+`{"platePixelSource":"source"}` keeps the Plate/Well/WellSample hierarchy and
+registers each child Image against the managed canonical Plate pixels. The
+optional `{"platePixelSource":"label","plateLabelName":"nuclei"}` registers
+the same hierarchy against that label under every image node, producing a
+mask-backed Plate view without copying arrays. BIOMERO creates these orders;
+ordinary importer clients can omit `ImportOptions`.
+
+The shallow collection remains the authoritative in-place result and receives
+a compact Plate-level OMERO annotation. Label-backed registration requires the
+named label to exist on every Plate image and fails rather than guessing when
+the selection is incomplete or ambiguous.
 
 ### Using the System Check Script
 
@@ -673,5 +691,4 @@ py -3.12 -m venv .venv
 ## LICENSE
 
 License changed to GPL-2.0 (starting version 1.3), as this work depends on `omero-py` and `ezomero` libraries for the OMERO import and session management.
-
 

--- a/biomero_importer/__init__.py
+++ b/biomero_importer/__init__.py
@@ -1,6 +1,11 @@
 from .main import run_application, DatabasePoller
 from .utils.initialize import load_settings, initialize_system
 from .utils.ingest_tracker import get_ingest_tracker, IngestTracker, IngestionTracking
+from .api import (
+    get_importer_capabilities,
+    submit_import_order,
+    supports_import_options,
+)
 
 __all__ = [
     "run_application",
@@ -9,5 +14,8 @@ __all__ = [
     "initialize_system",
     "get_ingest_tracker",
     "IngestTracker",
-    "IngestionTracking"
+    "IngestionTracking",
+    "get_importer_capabilities",
+    "submit_import_order",
+    "supports_import_options",
 ]

--- a/biomero_importer/api.py
+++ b/biomero_importer/api.py
@@ -1,0 +1,101 @@
+"""Stable client-facing API for BIOMERO.importer upload orders."""
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+from biomero_schema.imports import (
+    SHALLOW_ZARR_OPERATION,
+    ImportOptionsEnvelope,
+    parse_import_options,
+)
+
+from .utils.ingest_tracker import STAGE_NEW_ORDER, log_ingestion_step
+
+
+IMPORTER_API_SCHEMA = 1
+
+
+class UnsupportedImportOperation(ValueError):
+    """Raised when an order requests an unavailable lifecycle operation."""
+
+
+def _flag_enabled(name: str, default: bool = False) -> bool:
+    import os
+
+    return os.getenv(name, str(default)).strip().lower() == "true"
+
+
+def get_importer_capabilities() -> dict[str, Any]:
+    """Return capabilities without requiring a running importer process."""
+
+    operations = []
+    if _flag_enabled("BIOMERO_SHALLOW_ZARR"):
+        operations.append(SHALLOW_ZARR_OPERATION)
+    return {
+        "schema": IMPORTER_API_SCHEMA,
+        "importOptionsSchemas": [1, 2],
+        "lifecycleOperations": operations,
+        "externalPreprocessing": True,
+    }
+
+
+def supports_import_options(
+    value: ImportOptionsEnvelope | Mapping[str, Any] | None,
+) -> bool:
+    """Return whether this importer can execute every requested operation."""
+
+    envelope = parse_import_options(value)
+    supported = set(get_importer_capabilities()["lifecycleOperations"])
+    return all(operation.kind in supported for operation in envelope.operations)
+
+
+def submit_import_order(
+    order: Mapping[str, Any],
+    *,
+    log_order=log_ingestion_step,
+) -> str:
+    """Validate and durably enqueue an import order.
+
+    Existing callers may keep using ``log_ingestion_step``. New clients get a
+    capability-checked API which normalizes the versioned options envelope
+    before the append-only pending event is written.
+    """
+
+    required = (
+        "Group",
+        "Username",
+        "UUID",
+        "DestinationID",
+        "DestinationType",
+        "Files",
+    )
+    missing = [name for name in required if name not in order]
+    if missing:
+        raise ValueError(
+            "Missing required import order fields: " + ", ".join(missing)
+        )
+    normalized = deepcopy(dict(order))
+    envelope = parse_import_options(normalized.get("ImportOptions"))
+    if envelope.operations and not supports_import_options(envelope):
+        requested = ", ".join(
+            operation.kind for operation in envelope.operations
+        )
+        raise UnsupportedImportOperation(
+            f"Importer does not support requested operation(s): {requested}"
+        )
+    # Preserve the old empty/flat representation unless a caller explicitly
+    # uses lifecycle operations. This makes submission behavior transparent to
+    # existing import setups and older readers of the event table.
+    if envelope.operations:
+        normalized["ImportOptions"] = envelope.to_dict()
+    log_order(normalized, STAGE_NEW_ORDER)
+    return str(normalized["UUID"])
+
+
+__all__ = [
+    "IMPORTER_API_SCHEMA",
+    "UnsupportedImportOperation",
+    "get_importer_capabilities",
+    "submit_import_order",
+    "supports_import_options",
+]

--- a/biomero_importer/main.py
+++ b/biomero_importer/main.py
@@ -277,7 +277,8 @@ class DatabasePoller:
                             'DestinationID': order.destination_id,
                             'DestinationType': order.destination_type,
                             'Files': order.files,
-                            'FileNames': order.file_names
+                            'FileNames': order.file_names,
+                            'ImportOptions': order.import_options,
                         }
 
                         # Add preprocessing details if they exist

--- a/biomero_importer/migrations/versions/92e8f9e637a1_add_import_options_to_imports.py
+++ b/biomero_importer/migrations/versions/92e8f9e637a1_add_import_options_to_imports.py
@@ -1,0 +1,25 @@
+"""add import options to imports
+
+Revision ID: 92e8f9e637a1
+Revises: 78d3d6d84aec
+Create Date: 2026-08-19
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "92e8f9e637a1"
+down_revision = "78d3d6d84aec"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "imports",
+        sa.Column("import_options", sa.Text(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("imports", "import_options")

--- a/biomero_importer/utils/canonical_promotion.py
+++ b/biomero_importer/utils/canonical_promotion.py
@@ -114,6 +114,62 @@ class CanonicalPromotionService:
         path = self.store.commit(staging_path, source)
         return CanonicalPromotionResult(source=source, path=path)
 
+    def index_existing(
+        self,
+        existing_path: str | Path,
+        *,
+        relative_path: str | Path,
+        source_object_type: Literal["Image", "Plate"],
+        source_object_id: int,
+        source_generation: int,
+        node_path: str,
+        original_identity: PixelIdentity,
+        existing_identity: PixelIdentity,
+        pixel_identity_origin: Literal[
+            "raw", "omero-pixels", "canonical-bootstrap"
+        ],
+        interchange_profile: str = "ngff-0.4-zarr-v2",
+        store_identity: str | None = None,
+    ) -> CanonicalPromotionResult:
+        """Index a verified Zarr already inside managed storage in place."""
+        if (
+            original_identity.node_path != node_path
+            or existing_identity.node_path != node_path
+        ):
+            raise CanonicalPixelMismatch(
+                "Original and existing identity node paths must match the "
+                f"canonical node path {node_path!r}"
+            )
+        if not self.identities_match(original_identity, existing_identity):
+            raise CanonicalPixelMismatch(
+                f"Existing pixels do not match {source_object_type} "
+                f"{source_object_id} generation {source_generation}"
+            )
+
+        path = Path(existing_path).resolve()
+        managed_path = self.store.resolve(relative_path)
+        if path != managed_path:
+            raise ValueError(
+                "Existing Zarr path does not match its managed relative path"
+            )
+        if not path.is_dir():
+            raise ValueError(f"Existing Zarr is not a directory: {path}")
+
+        source = CanonicalZarrSource(
+            storage_root=self.storage_root_id,
+            relative_path=Path(relative_path).as_posix(),
+            node_path=node_path,
+            source_object_type=source_object_type,
+            source_object_id=source_object_id,
+            source_generation=source_generation,
+            interchange_profile=interchange_profile,
+            pixel_identity=original_identity,
+            pixel_identity_origin=pixel_identity_origin,
+            canonical_pixel_verified=True,
+            store_identity=store_identity,
+        )
+        return CanonicalPromotionResult(source=source, path=path)
+
 
 __all__ = [
     "CanonicalPixelMismatch",

--- a/biomero_importer/utils/canonical_promotion.py
+++ b/biomero_importer/utils/canonical_promotion.py
@@ -1,0 +1,122 @@
+"""Verified promotion of workflow-exported Zarrs into canonical storage."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Literal, Protocol
+
+from biomero_schema.zarr import CanonicalZarrSource, PixelIdentity
+
+
+class CanonicalStoreLike(Protocol):
+    def relative_path_for(
+        self,
+        source_directory: str | Path,
+        object_type: str,
+        object_id: int,
+        source_generation: int,
+    ) -> Path: ...
+
+    def commit(
+        self,
+        staging_path: str | Path,
+        source: CanonicalZarrSource,
+    ) -> Path: ...
+
+
+class CanonicalPixelMismatch(RuntimeError):
+    """An exported candidate does not represent the selected original pixels."""
+
+
+@dataclass(frozen=True)
+class CanonicalPromotionResult:
+    """The committed source record and its local managed path."""
+
+    source: CanonicalZarrSource
+    path: Path
+
+
+class CanonicalPromotionService:
+    """Verify and transactionally commit one deterministic canonical Zarr."""
+
+    def __init__(
+        self,
+        *,
+        storage_root_id: str,
+        storage_root: str | Path,
+        canonical_store_factory: Callable[[str | Path], CanonicalStoreLike] | None = None,
+        identities_match: Callable[[PixelIdentity, PixelIdentity], bool] | None = None,
+    ) -> None:
+        if not storage_root_id:
+            raise ValueError("storage_root_id must not be empty")
+        if canonical_store_factory is None:
+            from biomero_importer.utils.canonical_store import CanonicalStore
+
+            canonical_store_factory = CanonicalStore
+        if identities_match is None:
+            from biomero_importer.utils.pixel_identity import pixel_identities_match
+
+            identities_match = pixel_identities_match
+        self.storage_root_id = storage_root_id
+        self.store = canonical_store_factory(storage_root)
+        self.identities_match = identities_match
+
+    def promote(
+        self,
+        staging_path: str | Path,
+        *,
+        source_directory: str | Path,
+        source_object_type: Literal["Image", "Plate"],
+        source_object_id: int,
+        source_generation: int,
+        node_path: str,
+        original_identity: PixelIdentity,
+        exported_identity: PixelIdentity,
+        pixel_identity_origin: Literal[
+            "raw", "omero-pixels", "canonical-bootstrap"
+        ],
+        interchange_profile: str = "ngff-0.4-zarr-v2",
+        store_identity: str | None = None,
+    ) -> CanonicalPromotionResult:
+        """Commit ``staging_path`` only after exact cross-source verification."""
+        if (
+            original_identity.node_path != node_path
+            or exported_identity.node_path != node_path
+        ):
+            raise CanonicalPixelMismatch(
+                "Original and exported identity node paths must match the "
+                f"canonical node path {node_path!r}"
+            )
+        if not self.identities_match(original_identity, exported_identity):
+            raise CanonicalPixelMismatch(
+                f"Exported pixels do not match {source_object_type} "
+                f"{source_object_id} generation {source_generation}"
+            )
+
+        relative_path = self.store.relative_path_for(
+            source_directory,
+            source_object_type,
+            source_object_id,
+            source_generation,
+        ).as_posix()
+        source = CanonicalZarrSource(
+            storage_root=self.storage_root_id,
+            relative_path=relative_path,
+            node_path=node_path,
+            source_object_type=source_object_type,
+            source_object_id=source_object_id,
+            source_generation=source_generation,
+            interchange_profile=interchange_profile,
+            pixel_identity=original_identity,
+            pixel_identity_origin=pixel_identity_origin,
+            canonical_pixel_verified=True,
+            store_identity=store_identity,
+        )
+        path = self.store.commit(staging_path, source)
+        return CanonicalPromotionResult(source=source, path=path)
+
+
+__all__ = [
+    "CanonicalPixelMismatch",
+    "CanonicalPromotionResult",
+    "CanonicalPromotionService",
+]

--- a/biomero_importer/utils/canonical_store.py
+++ b/biomero_importer/utils/canonical_store.py
@@ -1,9 +1,12 @@
 """Transactional storage primitives for canonical BIOMERO Zarrs."""
 
 from contextlib import contextmanager
+import errno
 import json
 import os
 from pathlib import Path
+import shutil
+import tempfile
 from typing import Any, Iterator, Mapping, Optional, Union
 
 from biomero_schema.zarr import CanonicalZarrSource
@@ -177,8 +180,32 @@ class CanonicalStore:
             )
             os.replace(marker_tmp, marker_path)
             destination.parent.mkdir(parents=True, exist_ok=True)
-            os.replace(staging_path, destination)
+            try:
+                os.replace(staging_path, destination)
+            except OSError as exc:
+                if exc.errno != errno.EXDEV:
+                    raise
+                self._copy_across_filesystems(staging_path, destination)
             return destination
+
+    @staticmethod
+    def _copy_across_filesystems(staging_path: Path, destination: Path) -> None:
+        """Copy beside the destination, atomically publish, then remove source."""
+        destination_staging = Path(tempfile.mkdtemp(
+            prefix=f".{destination.name}.staging-",
+            dir=destination.parent,
+        ))
+        try:
+            shutil.copytree(
+                staging_path,
+                destination_staging,
+                dirs_exist_ok=True,
+            )
+            os.replace(destination_staging, destination)
+        except Exception:
+            shutil.rmtree(destination_staging, ignore_errors=True)
+            raise
+        shutil.rmtree(staging_path)
 
     @staticmethod
     def _validate_zarr(path: Path) -> None:

--- a/biomero_importer/utils/canonical_store.py
+++ b/biomero_importer/utils/canonical_store.py
@@ -1,0 +1,203 @@
+"""Transactional storage primitives for canonical BIOMERO Zarrs."""
+
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Optional, Union
+
+from biomero_schema.zarr import CanonicalZarrSource
+
+
+CANONICAL_MARKER_NAME = ".biomero-canonical.json"
+CANONICAL_MARKER_SCHEMA = 1
+PROCESSED_DATA_FOLDER = ".processed"
+CanonicalSourceLike = Union[CanonicalZarrSource, Mapping[str, Any]]
+
+
+def _source_payload(source: CanonicalSourceLike) -> dict[str, Any]:
+    """Return the shared schema's stable wire representation."""
+    if isinstance(source, CanonicalZarrSource):
+        return source.to_dict()
+    return CanonicalZarrSource.from_dict(source).to_dict()
+
+
+class InvalidCanonicalStore(RuntimeError):
+    """A canonical destination exists but cannot safely be adopted."""
+
+
+class CanonicalCreationLocked(RuntimeError):
+    """Another process is creating the same canonical Zarr."""
+
+
+class CanonicalStore:
+    """Resolves and commits canonical Zarrs beneath one managed storage root."""
+
+    def __init__(self, storage_root: Union[str, Path]):
+        self.storage_root = Path(storage_root).resolve()
+
+    @staticmethod
+    def canonical_name(
+        object_type: str, object_id: int, source_generation: int
+    ) -> str:
+        if object_type not in {"Image", "Plate"}:
+            raise ValueError("object_type must be Image or Plate")
+        if object_id < 1 or source_generation < 1:
+            raise ValueError("object_id and source_generation must be positive")
+        return f"{object_type}-{object_id}.g{source_generation}.ome.zarr"
+
+    def relative_path_for(
+        self,
+        source_directory: Union[str, Path],
+        object_type: str,
+        object_id: int,
+        source_generation: int,
+    ) -> Path:
+        source_directory = Path(source_directory)
+        if source_directory.is_absolute() or ".." in source_directory.parts:
+            raise ValueError("source_directory must be relative to managed storage")
+        return (
+            source_directory
+            / PROCESSED_DATA_FOLDER
+            / self.canonical_name(object_type, object_id, source_generation)
+        )
+
+    def resolve(self, relative_path: Union[str, Path]) -> Path:
+        relative_path = Path(relative_path)
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            raise ValueError("Path escapes the managed storage root")
+        candidate = (self.storage_root / relative_path).resolve()
+        try:
+            candidate.relative_to(self.storage_root)
+        except ValueError as exc:
+            raise ValueError("Path escapes the managed storage root") from exc
+        return candidate
+
+    def destination_for(self, source: CanonicalSourceLike) -> Path:
+        source_payload = _source_payload(source)
+        destination = self.resolve(str(source_payload["relativePath"]))
+        expected_name = self.canonical_name(
+            str(source_payload["sourceObjectType"]),
+            int(source_payload["sourceObjectId"]),
+            int(source_payload["sourceGeneration"]),
+        )
+        if destination.name != expected_name:
+            raise ValueError(
+                f"Canonical path must end with {expected_name}, got "
+                f"{destination.name}"
+            )
+        return destination
+
+    @contextmanager
+    def creation_lock(
+        self, source: CanonicalSourceLike
+    ) -> Iterator[Path]:
+        destination = self.destination_for(source)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = destination.with_name(destination.name + ".lock")
+        try:
+            descriptor = os.open(
+                lock_path,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+            )
+        except FileExistsError as exc:
+            raise CanonicalCreationLocked(
+                f"Canonical creation is already locked: {destination}"
+            ) from exc
+        try:
+            os.write(descriptor, str(os.getpid()).encode("ascii"))
+            os.close(descriptor)
+            descriptor = None
+            yield destination
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            lock_path.unlink(missing_ok=True)
+
+    def adopt(self, source: CanonicalSourceLike) -> Optional[Path]:
+        """Returns a matching committed canonical, or None when absent."""
+        source_payload = _source_payload(source)
+        destination = self.destination_for(source)
+        if not destination.exists():
+            return None
+        self._validate_zarr(destination)
+        marker_path = destination / CANONICAL_MARKER_NAME
+        if not marker_path.is_file():
+            raise InvalidCanonicalStore(
+                f"Canonical store has no committed marker: {destination}"
+            )
+        try:
+            marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise InvalidCanonicalStore(
+                f"Canonical marker is unreadable: {marker_path}"
+            ) from exc
+        if (
+            marker.get("markerSchema") != CANONICAL_MARKER_SCHEMA
+            or marker.get("state") != "committed"
+        ):
+            raise InvalidCanonicalStore(
+                f"Canonical marker is not committed: {marker_path}"
+            )
+        if marker.get("source") != source_payload:
+            raise InvalidCanonicalStore(
+                f"Canonical marker does not match requested source: {destination}"
+            )
+        return destination
+
+    def commit(
+        self,
+        staging_path: Union[str, Path],
+        source: CanonicalSourceLike,
+    ) -> Path:
+        """Atomically promotes a verified staging Zarr with its recovery marker."""
+        staging_path = Path(staging_path)
+        if not staging_path.is_absolute():
+            staging_path = staging_path.resolve()
+        self._validate_zarr(staging_path)
+
+        with self.creation_lock(source) as destination:
+            existing = self.adopt(source)
+            if existing is not None:
+                return existing
+            if destination.exists():
+                raise InvalidCanonicalStore(
+                    f"Uncommitted canonical destination already exists: {destination}"
+                )
+            marker = {
+                "markerSchema": CANONICAL_MARKER_SCHEMA,
+                "state": "committed",
+                "source": _source_payload(source),
+            }
+            marker_tmp = staging_path / f"{CANONICAL_MARKER_NAME}.tmp"
+            marker_path = staging_path / CANONICAL_MARKER_NAME
+            marker_tmp.write_text(
+                json.dumps(marker, indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+            os.replace(marker_tmp, marker_path)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(staging_path, destination)
+            return destination
+
+    @staticmethod
+    def _validate_zarr(path: Path) -> None:
+        if not path.is_dir():
+            raise InvalidCanonicalStore(f"Canonical Zarr is not a directory: {path}")
+        if (path / ".zgroup").is_file() or (path / "zarr.json").is_file():
+            return
+        metadata = path / "OME" / "METADATA.ome.xml"
+        has_numbered_series = any(
+            child.is_dir()
+            and child.name.isdigit()
+            and (
+                (child / ".zgroup").is_file()
+                or (child / "zarr.json").is_file()
+            )
+            for child in path.iterdir()
+        )
+        if metadata.is_file() and has_numbered_series:
+            return
+        raise InvalidCanonicalStore(
+            f"Path is not a supported Zarr or bioformats2raw layout: {path}"
+        )

--- a/biomero_importer/utils/canonical_store.py
+++ b/biomero_importer/utils/canonical_store.py
@@ -9,19 +9,25 @@ import shutil
 import tempfile
 from typing import Any, Iterator, Mapping, Optional, Union
 
-from biomero_schema.zarr import CanonicalZarrSource
+from biomero_schema.zarr import CanonicalPlateSource, CanonicalZarrSource
 
 
 CANONICAL_MARKER_NAME = ".biomero-canonical.json"
 CANONICAL_MARKER_SCHEMA = 1
 PROCESSED_DATA_FOLDER = ".processed"
-CanonicalSourceLike = Union[CanonicalZarrSource, Mapping[str, Any]]
+CanonicalSourceLike = Union[
+    CanonicalZarrSource,
+    CanonicalPlateSource,
+    Mapping[str, Any],
+]
 
 
 def _source_payload(source: CanonicalSourceLike) -> dict[str, Any]:
     """Return the shared schema's stable wire representation."""
-    if isinstance(source, CanonicalZarrSource):
+    if isinstance(source, (CanonicalZarrSource, CanonicalPlateSource)):
         return source.to_dict()
+    if "images" in source and "sourceObjectType" not in source:
+        return CanonicalPlateSource.from_dict(source).to_dict()
     return CanonicalZarrSource.from_dict(source).to_dict()
 
 
@@ -80,7 +86,7 @@ class CanonicalStore:
         source_payload = _source_payload(source)
         destination = self.resolve(str(source_payload["relativePath"]))
         expected_name = self.canonical_name(
-            str(source_payload["sourceObjectType"]),
+            str(source_payload.get("sourceObjectType", "Plate")),
             int(source_payload["sourceObjectId"]),
             int(source_payload["sourceGeneration"]),
         )

--- a/biomero_importer/utils/canonical_store.py
+++ b/biomero_importer/utils/canonical_store.py
@@ -14,6 +14,7 @@ from biomero_schema.zarr import CanonicalPlateSource, CanonicalZarrSource
 
 CANONICAL_MARKER_NAME = ".biomero-canonical.json"
 CANONICAL_MARKER_SCHEMA = 1
+CANONICAL_METADATA_DIRECTORY = ".biomero"
 PROCESSED_DATA_FOLDER = ".processed"
 CanonicalSourceLike = Union[
     CanonicalZarrSource,
@@ -234,3 +235,76 @@ class CanonicalStore:
         raise InvalidCanonicalStore(
             f"Path is not a supported Zarr or bioformats2raw layout: {path}"
         )
+
+
+def external_canonical_marker_path(zarr_path: Union[str, Path]) -> Path:
+    """Return the managed sidecar path without writing into source pixels."""
+    zarr_path = Path(zarr_path)
+    return (
+        zarr_path.parent
+        / CANONICAL_METADATA_DIRECTORY
+        / f"{zarr_path.name}.canonical.json"
+    )
+
+
+def write_indexed_canonical_marker(
+    zarr_path: Union[str, Path],
+    source: CanonicalSourceLike,
+) -> Path:
+    """Atomically persist detailed identities beside an indexed managed Zarr."""
+    zarr_path = Path(zarr_path).resolve()
+    CanonicalStore._validate_zarr(zarr_path)
+    marker_path = external_canonical_marker_path(zarr_path)
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker = {
+        "markerSchema": CANONICAL_MARKER_SCHEMA,
+        "state": "committed",
+        "source": _source_payload(source),
+    }
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{marker_path.name}.",
+        suffix=".tmp",
+        dir=marker_path.parent,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(marker, handle, indent=2, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, marker_path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+    return marker_path
+
+
+def load_canonical_marker(
+    zarr_path: Union[str, Path],
+) -> Optional[Union[CanonicalZarrSource, CanonicalPlateSource]]:
+    """Load a committed internal or non-invasive external canonical marker."""
+    zarr_path = Path(zarr_path).resolve()
+    candidates = (
+        zarr_path / CANONICAL_MARKER_NAME,
+        external_canonical_marker_path(zarr_path),
+    )
+    marker_path = next((path for path in candidates if path.is_file()), None)
+    if marker_path is None:
+        return None
+    try:
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise InvalidCanonicalStore(
+            f"Canonical marker is unreadable: {marker_path}"
+        ) from exc
+    if (
+        marker.get("markerSchema") != CANONICAL_MARKER_SCHEMA
+        or marker.get("state") != "committed"
+        or not isinstance(marker.get("source"), dict)
+    ):
+        raise InvalidCanonicalStore(
+            f"Canonical marker is not committed: {marker_path}"
+        )
+    payload = marker["source"]
+    if "images" in payload and "sourceObjectType" not in payload:
+        return CanonicalPlateSource.from_dict(payload)
+    return CanonicalZarrSource.from_dict(payload)

--- a/biomero_importer/utils/importer.py
+++ b/biomero_importer/utils/importer.py
@@ -30,6 +30,9 @@ PODMAN_RUN_MAX_ATTEMPTS = 3  # Bounded retries for transient bind setup failures
 PODMAN_RUN_RETRY_DELAY = 2  # Initial retry delay, doubled after each failure
 TMP_OUTPUT_FOLDER = "OMERO_inplace"
 PROCESSED_DATA_FOLDER = ".processed"
+SHALLOW_ZARR_ENABLED = (
+    os.getenv("BIOMERO_SHALLOW_ZARR", "false").lower() == "true"
+)
 
 # A CIFS/DFS referral reconnect can make Podman's first bind-source statfs fail
 # even though the same mount succeeds immediately afterward. Keep this exact so
@@ -603,7 +606,22 @@ class DataPackageImporter:
         import zarr
         from types import SimpleNamespace
 
-        file_title = os.path.splitext(os.path.basename(uri))[0].rstrip('.ome')
+        logical_uri = str(uri)
+        file_title = os.path.splitext(os.path.basename(logical_uri))[0].rstrip('.ome')
+        shallow_registration = None
+        if SHALLOW_ZARR_ENABLED:
+            from .result_zarr import resolve_shallow_registration
+
+            shallow_registration = resolve_shallow_registration(logical_uri)
+            if shallow_registration is not None:
+                uri = str(shallow_registration.registration_path)
+                self.logger.info(
+                    "Resolved %s shallow Zarr registration %s to pixel backing %s",
+                    shallow_registration.kind,
+                    logical_uri,
+                    uri,
+                )
+
         args = SimpleNamespace(uri=uri, endpoint=endpoint, name=file_title,
                                nosignrequest=nosignrequest, target=str(target), target_by_name=target_by_name)
 
@@ -679,16 +697,39 @@ class DataPackageImporter:
             for obj in objs:
                 link_to_target(args, conn, obj)
 
+        if shallow_registration is not None:
+            from biomero_schema.zarr import SHALLOW_COLLECTION_NAMESPACE
+
+            object_type = "Plate" if "plate" in zattrs else "Image"
+            for obj in objs:
+                object_id = obj.getId().getValue()
+                ezomero.post_map_annotation(
+                    conn=conn,
+                    object_type=object_type,
+                    object_id=object_id,
+                    kv_dict=(
+                        shallow_registration.reference.to_annotation_values()
+                    ),
+                    ns=SHALLOW_COLLECTION_NAMESPACE,
+                    across_groups=False,
+                )
+                self.logger.info(
+                    "Attached shallow collection reference to %s %s: %s",
+                    object_type,
+                    object_id,
+                    shallow_registration.collection_root,
+                )
+
         # --- end copy from register.main() ---
 
         image_ids = [obj.getId().getValue() for obj in objs]
         is_plate = "plate" in zattrs
         if image_ids:
             self.imported = True
-            self.logger.info(f'Import successfully for {uri}')
+            self.logger.info(f'Import successfully for {logical_uri}')
         else:
             self.imported = False
-            self.logger.error(f'Import failed for {uri}')
+            self.logger.error(f'Import failed for {logical_uri}')
         return image_ids, is_plate
 
     @connection

--- a/biomero_importer/utils/importer.py
+++ b/biomero_importer/utils/importer.py
@@ -609,12 +609,25 @@ class DataPackageImporter:
         logical_uri = str(uri)
         file_title = os.path.splitext(os.path.basename(logical_uri))[0].rstrip('.ome')
         shallow_registration = None
+        import_options = None
         if SHALLOW_ZARR_ENABLED:
+            from biomero_schema.zarr import ZarrImportOptions
             from .result_zarr import resolve_shallow_registration
 
-            shallow_registration = resolve_shallow_registration(logical_uri)
+            import_options = ZarrImportOptions.from_dict(
+                self.data_package.get("ImportOptions", {})
+            )
+            shallow_registration = resolve_shallow_registration(
+                logical_uri,
+                import_options=import_options,
+            )
             if shallow_registration is not None:
                 uri = str(shallow_registration.registration_path)
+                if shallow_registration.plate_label_name is not None:
+                    file_title = (
+                        f"{file_title} "
+                        f"[{shallow_registration.plate_label_name}]"
+                    )
                 self.logger.info(
                     "Resolved %s shallow Zarr registration %s to pixel backing %s",
                     shallow_registration.kind,
@@ -622,8 +635,22 @@ class DataPackageImporter:
                     uri,
                 )
 
-        args = SimpleNamespace(uri=uri, endpoint=endpoint, name=file_title,
-                               nosignrequest=nosignrequest, target=str(target), target_by_name=target_by_name)
+        args = SimpleNamespace(
+            uri=uri,
+            endpoint=endpoint,
+            name=file_title,
+            nosignrequest=nosignrequest,
+            target=str(target),
+            target_by_name=target_by_name,
+            plate_label_paths=(
+                dict(shallow_registration.plate_label_paths)
+                if shallow_registration is not None else {}
+            ),
+            plate_label_name=(
+                shallow_registration.plate_label_name
+                if shallow_registration is not None else None
+            ),
+        )
 
         # --- start copy from register.main() ---
 

--- a/biomero_importer/utils/importer.py
+++ b/biomero_importer/utils/importer.py
@@ -611,12 +611,12 @@ class DataPackageImporter:
         shallow_registration = None
         import_options = None
         if SHALLOW_ZARR_ENABLED:
-            from biomero_schema.zarr import ZarrImportOptions
+            from biomero_schema.imports import parse_import_options
             from .result_zarr import resolve_shallow_registration
 
-            import_options = ZarrImportOptions.from_dict(
+            import_options = parse_import_options(
                 self.data_package.get("ImportOptions", {})
-            )
+            ).registration
             shallow_registration = resolve_shallow_registration(
                 logical_uri,
                 import_options=import_options,
@@ -1088,6 +1088,41 @@ class DataPackageImporter:
                     (file_path, upload_target, os.path.basename(file_path), None))
         return successful_uploads, failed_uploads
 
+    def upload_prepared_plan(
+        self,
+        conn,
+        plan,
+        *,
+        dataset_id=None,
+        screen_id=None,
+    ):
+        """Import lifecycle-planned views through the existing upload path."""
+        successful = []
+        failed = []
+        original_options = self.data_package.get("ImportOptions")
+        try:
+            for item in plan.items:
+                self.logger.info(
+                    "Importing prepared %s view from %s",
+                    item.role,
+                    item.path,
+                )
+                self.data_package["ImportOptions"] = item.registration.to_dict()
+                item_successful, item_failed = self.upload_files(
+                    conn,
+                    [str(item.path)],
+                    dataset_id=dataset_id,
+                    screen_id=screen_id,
+                )
+                successful.extend(item_successful)
+                failed.extend(item_failed)
+        finally:
+            if original_options is None:
+                self.data_package.pop("ImportOptions", None)
+            else:
+                self.data_package["ImportOptions"] = original_options
+        return successful, failed
+
     @connection
     def rename_image_if_needed(self, conn, image_id, local_path):
         """Rename Image to the full name specified by the preprocessor container.
@@ -1285,6 +1320,7 @@ class DataPackageImporter:
 
                             processor = DataProcessor(
                                 self.data_package, self.logger)
+                            lifecycle_plan = None
                             if processor.has_preprocessing():
                                 # Setup a local tmp folder on the OMERO server itself
                                 local_tmp_folder = get_tmp_output_path(
@@ -1320,8 +1356,37 @@ class DataPackageImporter:
 
                                 # Results already persisted by processor.run() under PREPROC_* keys
 
+                                from biomero_schema.imports import parse_import_options
+                                options = parse_import_options(
+                                    self.data_package.get("ImportOptions")
+                                )
+                                if options.operations:
+                                    from .lifecycle import ImportLifecycleEngine
+
+                                    lifecycle_files = [
+                                        result.get(PREPROC_RESULT_LOCAL_FULL)
+                                        for result in self.data_package.get(
+                                            PREPROC_RESULTS_KEY, []
+                                        )
+                                        if result.get(PREPROC_RESULT_LOCAL_FULL)
+                                    ]
+                                    if not lifecycle_files:
+                                        lifecycle_files = local_paths
+                                    lifecycle_plan = ImportLifecycleEngine(
+                                        self.logger
+                                    ).prepare(lifecycle_files, options)
+
                                 # Pass the target id based on its type; include local paths if preprocessed
-                                if is_screen:
+                                if lifecycle_plan is not None:
+                                    successful_uploads, failed_uploads = (
+                                        self.upload_prepared_plan(
+                                            user_conn,
+                                            lifecycle_plan,
+                                            dataset_id=(None if is_screen else target_id),
+                                            screen_id=(target_id if is_screen else None),
+                                        )
+                                    )
+                                elif is_screen:
                                     successful_uploads, failed_uploads = self.upload_files(
                                         user_conn, file_paths, dataset_id=None, screen_id=target_id, local_paths=local_paths
                                     )
@@ -1332,7 +1397,29 @@ class DataPackageImporter:
                             else:
                                 self.logger.info(
                                     "No preprocessing required; continuing upload.")
-                                if is_screen:
+                                from biomero_schema.imports import parse_import_options
+                                options = parse_import_options(
+                                    self.data_package.get("ImportOptions")
+                                )
+                                if options.operations:
+                                    from .lifecycle import ImportLifecycleEngine
+
+                                    log_ingestion_step(
+                                        self.data_package,
+                                        STAGE_PREPROCESSING,
+                                    )
+                                    lifecycle_plan = ImportLifecycleEngine(
+                                        self.logger
+                                    ).prepare(file_paths, options)
+                                    successful_uploads, failed_uploads = (
+                                        self.upload_prepared_plan(
+                                            user_conn,
+                                            lifecycle_plan,
+                                            dataset_id=(None if is_screen else target_id),
+                                            screen_id=(target_id if is_screen else None),
+                                        )
+                                    )
+                                elif is_screen:
                                     successful_uploads, failed_uploads = self.upload_files(
                                         user_conn,
                                         file_paths,

--- a/biomero_importer/utils/ingest_tracker.py
+++ b/biomero_importer/utils/ingest_tracker.py
@@ -126,6 +126,7 @@ class IngestionTracking(Base):
     timestamp = Column(DateTime(timezone=True), default=func.now())
     _files = Column("files", Text, nullable=False)
     _file_names = Column("file_names", Text, nullable=True)
+    _import_options = Column("import_options", Text, nullable=True)
     # Optional human-readable description for the step (e.g., failure reason)
     description = Column(Text, nullable=True)
 
@@ -148,6 +149,16 @@ class IngestionTracking(Base):
     @file_names.setter
     def file_names(self, file_names):
         self._file_names = json.dumps(file_names)
+
+    @property
+    def import_options(self):
+        return json.loads(self._import_options) if self._import_options else {}
+
+    @import_options.setter
+    def import_options(self, import_options):
+        self._import_options = (
+            json.dumps(import_options) if import_options else None
+        )
 
 
 # Define the index outside of the class
@@ -267,6 +278,7 @@ class IngestTracker:
                         uuid=str(order_info.get('UUID', 'Unknown')),
                         files=order_info.get('Files', []),
                         file_names=order_info.get('FileNames', []),
+                        import_options=order_info.get('ImportOptions', {}),
                         description=(
                             order_info.get('Description')
                             or order_info.get('description')

--- a/biomero_importer/utils/initialize.py
+++ b/biomero_importer/utils/initialize.py
@@ -140,7 +140,8 @@ def finalize_dangling_orders_and_get_last_id(ingest_tracker, IngestionTracking, 
                     destination_id=original_order.destination_id,
                     destination_type=original_order.destination_type,
                     files=original_order.files,
-                    file_names=original_order.file_names
+                    file_names=original_order.file_names,
+                    import_options=original_order.import_options,
                     # Include additional fields if necessary
                 )
                 session.add(new_failed_entry)

--- a/biomero_importer/utils/lifecycle.py
+++ b/biomero_importer/utils/lifecycle.py
@@ -1,0 +1,308 @@
+"""Registration-independent lifecycle operations for importer orders."""
+
+from dataclasses import dataclass
+import json
+import logging
+import os
+from pathlib import Path, PurePosixPath
+from typing import Literal, Sequence
+
+from biomero_schema.imports import (
+    SHALLOW_ZARR_OPERATION,
+    ImportOptionsEnvelope,
+    ShallowZarrImportOperation,
+    parse_import_options,
+)
+from biomero_schema.zarr import (
+    SHALLOW_COLLECTION_MANIFEST,
+    ShallowCollection,
+    ZarrImportOptions,
+)
+
+from .pixel_identity import PixelIdentityError
+from .result_zarr import (
+    ReturnedZarrDecision,
+    discover_ngff_nodes,
+    evaluate_returned_zarr,
+    normalize_returned_zarr,
+)
+
+
+@dataclass(frozen=True)
+class PreparedImportItem:
+    """One physical path and registration view produced by the lifecycle."""
+
+    path: Path
+    registration: ZarrImportOptions
+    role: Literal["input", "primary", "image-label", "plate-label-preview"]
+
+
+@dataclass(frozen=True)
+class PreparedImportPlan:
+    """Deterministic importer inputs after all requested native operations."""
+
+    items: tuple[PreparedImportItem, ...]
+    options: ImportOptionsEnvelope
+    decisions: tuple[ReturnedZarrDecision, ...] = ()
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.options.operations)
+
+
+def _positive_int_env(name: str, default: int, logger: logging.Logger) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+        if parsed < 1:
+            raise ValueError
+        return parsed
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r; using %s", name, value, default)
+        return default
+
+
+def _is_zarr(path: Path) -> bool:
+    return path.is_dir() and (
+        path.name.lower().endswith(".zarr")
+        or (path / ".zattrs").is_file()
+        or (path / "zarr.json").is_file()
+    )
+
+
+def _load_shallow_collection(path: Path) -> ShallowCollection | None:
+    manifest = path / SHALLOW_COLLECTION_MANIFEST
+    if not manifest.is_file():
+        return None
+    try:
+        return ShallowCollection.from_dict(json.loads(
+            manifest.read_text(encoding="utf-8")
+        ))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise PixelIdentityError(
+            f"Invalid existing shallow collection: {manifest}"
+        ) from exc
+
+
+def _common_plate_label(
+    collection: ShallowCollection,
+    requested: str | None,
+) -> str | None:
+    labels_per_image = []
+    for image in collection.images:
+        if image.source.source_object_type != "Plate":
+            return None
+        prefix = PurePosixPath(image.image_node_path) / "labels"
+        names = set()
+        for path in image.label_node_paths:
+            try:
+                relative = PurePosixPath(path).relative_to(prefix)
+            except ValueError:
+                continue
+            if len(relative.parts) == 1:
+                names.add(relative.name)
+        labels_per_image.append(names)
+    common = set.intersection(*labels_per_image) if labels_per_image else set()
+    if requested:
+        return requested if requested in common else None
+    return next(iter(common)) if len(common) == 1 else None
+
+
+def _items_for_shallow_collection(
+    root: Path,
+    collection: ShallowCollection,
+    operation: ShallowZarrImportOperation,
+) -> tuple[PreparedImportItem, ...]:
+    source_types = {
+        image.source.source_object_type for image in collection.images
+    }
+    if source_types == {"Plate"}:
+        items = [PreparedImportItem(
+            path=root,
+            registration=ZarrImportOptions(),
+            role="primary",
+        )]
+        if operation.import_plate_label_preview:
+            label_name = _common_plate_label(
+                collection,
+                operation.plate_label_name,
+            )
+            if label_name is not None:
+                items.append(PreparedImportItem(
+                    path=root,
+                    registration=ZarrImportOptions(
+                        platePixelSource="label",
+                        plateLabelName=label_name,
+                    ),
+                    role="plate-label-preview",
+                ))
+        return tuple(items)
+
+    if source_types != {"Image"}:
+        raise PixelIdentityError(
+            "Shallow collection must contain only Image or only Plate sources"
+        )
+    if not operation.import_image_label_views:
+        return ()
+    items = []
+    for image in collection.images:
+        local_components = (
+            component for component in image.label_components
+            if component.source is None
+        )
+        paths = (
+            tuple(component.logical_node_path for component in local_components)
+            if image.label_components
+            else image.label_node_paths
+        )
+        items.extend(
+            PreparedImportItem(
+                path=root.joinpath(*PurePosixPath(path).parts),
+                registration=ZarrImportOptions(),
+                role="image-label",
+            )
+            for path in paths
+        )
+    return tuple(items)
+
+
+def _full_result_items(
+    root: Path,
+    operation: ShallowZarrImportOperation,
+    registration: ZarrImportOptions,
+) -> tuple[PreparedImportItem, ...]:
+    items = [PreparedImportItem(root, registration, "primary")]
+    if not operation.import_image_label_views:
+        return tuple(items)
+    try:
+        nodes = discover_ngff_nodes(root)
+    except PixelIdentityError:
+        return tuple(items)
+    image_nodes = tuple(node for node in nodes if node.role == "image")
+    if len(image_nodes) != 1 or image_nodes[0].node_path != ".":
+        return tuple(items)
+    items.extend(
+        PreparedImportItem(
+            root.joinpath(*PurePosixPath(node.node_path).parts),
+            ZarrImportOptions(),
+            "image-label",
+        )
+        for node in nodes
+        if node.role == "label"
+    )
+    return tuple(items)
+
+
+class ImportLifecycleEngine:
+    """Execute optional native operations without knowing register.py."""
+
+    def __init__(self, logger: logging.Logger | None = None):
+        self.logger = logger or logging.getLogger(__name__)
+
+    def prepare(
+        self,
+        files: Sequence[str | Path],
+        options: ImportOptionsEnvelope | dict | None,
+    ) -> PreparedImportPlan:
+        envelope = parse_import_options(options)
+        if not envelope.operations:
+            return PreparedImportPlan(
+                items=tuple(
+                    PreparedImportItem(
+                        Path(path), envelope.registration, "input"
+                    )
+                    for path in files
+                ),
+                options=envelope,
+            )
+        items = tuple(
+            PreparedImportItem(Path(path), envelope.registration, "input")
+            for path in files
+        )
+        decisions = ()
+        for operation in envelope.operations:
+            if operation.kind != SHALLOW_ZARR_OPERATION:
+                raise ValueError(
+                    f"Unsupported importer lifecycle operation {operation.kind}"
+                )
+            items, decisions = self._prepare_shallow(items, operation)
+        return PreparedImportPlan(
+            items=items,
+            options=envelope,
+            decisions=decisions,
+        )
+
+    def _prepare_shallow(
+        self,
+        current: tuple[PreparedImportItem, ...],
+        operation: ShallowZarrImportOperation,
+    ) -> tuple[tuple[PreparedImportItem, ...], tuple[ReturnedZarrDecision, ...]]:
+        if os.getenv("BIOMERO_SHALLOW_ZARR", "false").lower() != "true":
+            raise ValueError(
+                "biomero.shallow-zarr requested but BIOMERO_SHALLOW_ZARR is disabled"
+            )
+        workers = _positive_int_env(
+            "BIOMERO_SHALLOW_ZARR_WORKERS", 1, self.logger
+        )
+        prepared = []
+        decisions = []
+        for item in current:
+            root = item.path
+            if not _is_zarr(root):
+                prepared.append(item)
+                continue
+            existing = _load_shallow_collection(root)
+            if existing is not None:
+                self.logger.info(
+                    "Reusing existing shallow Zarr manifest for %s", root
+                )
+                prepared.extend(_items_for_shallow_collection(
+                    root, existing, operation
+                ))
+                continue
+            self.logger.info(
+                "Evaluating returned Zarr %s with %s identity worker(s)",
+                root,
+                workers,
+            )
+            decision = evaluate_returned_zarr(
+                root,
+                operation.canonical_inputs,
+                identity_workers=workers,
+            )
+            decisions.append(decision)
+            self.logger.info(
+                "Returned Zarr decision for %s: %s (%s)",
+                root,
+                decision.outcome,
+                decision.reason,
+            )
+            if decision.unchanged_passthrough:
+                continue
+            if not decision.eligible:
+                prepared.extend(_full_result_items(
+                    root, operation, item.registration
+                ))
+                continue
+            normalized = normalize_returned_zarr(
+                decision,
+                operation.canonical_inputs.workflow_id,
+            )
+            self.logger.info(
+                "Stored shallow Zarr %s with %s image node(s)",
+                root,
+                len(normalized.collection.images),
+            )
+            prepared.extend(_items_for_shallow_collection(
+                root, normalized.collection, operation
+            ))
+        return tuple(prepared), tuple(decisions)
+
+
+__all__ = [
+    "ImportLifecycleEngine",
+    "PreparedImportItem",
+    "PreparedImportPlan",
+]

--- a/biomero_importer/utils/pixel_identity.py
+++ b/biomero_importer/utils/pixel_identity.py
@@ -9,7 +9,9 @@ from dataclasses import dataclass
 from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version
 import json
+import os
 from pathlib import Path, PurePosixPath
+import tempfile
 from typing import Any, Callable, Literal, Mapping, Sequence
 
 from biomero_schema.zarr import PixelIdentity
@@ -196,7 +198,27 @@ class IsccBioIdentityProvider:
         # pyramid arrays of a normal multiscale image for bioformats2raw
         # series. BioIO follows the same upstream IMAGEWALK contract without
         # duplicating hashing or traversal here.
-        results = list(generate(target, source_type="bioio"))
+        if target.name.lower().endswith(".zarr"):
+            results = list(generate(target, source_type="bioio"))
+        else:
+            # BioIO selects its reader from the path suffix. NGFF Plate image
+            # nodes and ordinary label nodes are valid standalone image groups
+            # but normally have names such as A/1/0 or labels/cells. Present a
+            # temporary, zero-copy *.ome.zarr alias so upstream ISCC-BIO can
+            # apply the same BioIO IMAGEWALK implementation used for root
+            # images. The managed store remains read-only.
+            with tempfile.TemporaryDirectory(
+                prefix="biomero-iscc-node-"
+            ) as temporary:
+                alias = Path(temporary) / "image.ome.zarr"
+                try:
+                    os.symlink(target, alias, target_is_directory=True)
+                except OSError as exc:
+                    raise PixelIdentityError(
+                        "Cannot create the temporary NGFF node alias required "
+                        "for ISCC-BIO"
+                    ) from exc
+                results = list(generate(alias, source_type="bioio"))
         return self._build_identity(
             results,
             source_description="An explicit Zarr node",

--- a/biomero_importer/utils/pixel_identity.py
+++ b/biomero_importer/utils/pixel_identity.py
@@ -1,0 +1,154 @@
+"""ISCC-BIO adapter for BIOMERO pixel identity contracts.
+
+Hashing and IMAGEWALK traversal stay in the upstream ``iscc-bio`` package. This
+module only selects one explicit image node, validates the public API result,
+and combines it with the semantic guard required by BIOMERO's shared contract.
+"""
+
+from importlib import import_module
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, Literal, Mapping, Sequence
+
+from biomero_schema.zarr import PixelIdentity
+
+
+BiocodeCallable = Callable[..., Sequence[Mapping[str, Any]]]
+ISCC_BIO_GIT_REVISION = "c536d7699b7d25592bfe5c91c947b749344b6914"
+
+
+class PixelIdentityError(RuntimeError):
+    """An exact pixel identity could not be calculated unambiguously."""
+
+
+def _validate_node_path(node_path: str) -> PurePosixPath:
+    if not node_path or "\\" in node_path:
+        raise PixelIdentityError(f"Unsafe Zarr node path: {node_path!r}")
+    parsed = PurePosixPath(node_path)
+    if parsed.is_absolute() or ".." in parsed.parts:
+        raise PixelIdentityError(f"Unsafe Zarr node path: {node_path!r}")
+    return parsed
+
+
+class IsccBioIdentityProvider:
+    """Generate one BIOMERO identity through ``iscc_bio.api.biocode``.
+
+    ``generate_biocode`` and ``tool_version`` are injectable so callers can test
+    orchestration without importing the sizeable reader stack. Production use
+    loads the public API lazily from the optional ``identity`` dependency.
+    """
+
+    def __init__(
+        self,
+        *,
+        generate_biocode: BiocodeCallable | None = None,
+        tool_version: str | None = None,
+        imagewalk_revision: str | None = None,
+    ) -> None:
+        self._generate_biocode = generate_biocode
+        self._tool_version = tool_version
+        self._imagewalk_revision = imagewalk_revision
+
+    def _load_upstream(self) -> tuple[BiocodeCallable, str]:
+        generate = self._generate_biocode
+        if generate is None:
+            try:
+                generate = import_module("iscc_bio.api").biocode
+            except ImportError as exc:
+                raise PixelIdentityError(
+                    "ISCC-BIO is unavailable; install biomero-importer with "
+                    "the identity extra"
+                ) from exc
+
+        tool_version = self._tool_version
+        if tool_version is None:
+            try:
+                tool_version = version("iscc-bio")
+            except PackageNotFoundError as exc:
+                raise PixelIdentityError(
+                    "Cannot determine the installed iscc-bio version"
+                ) from exc
+        return generate, tool_version
+
+    def generate(
+        self,
+        zarr_root: str | Path,
+        *,
+        node_path: str,
+        role: Literal["image", "label"],
+        shape: Sequence[int],
+        dtype: str,
+        axes: Sequence[str],
+        coordinate_transformations: Sequence[Mapping[str, Any]] = (),
+    ) -> PixelIdentity:
+        """Hash exactly one Zarr image node and attach its semantic guard."""
+        parsed_node = _validate_node_path(node_path)
+        target = Path(zarr_root)
+        if node_path != ".":
+            target = target.joinpath(*parsed_node.parts)
+
+        generate, tool_version = self._load_upstream()
+        results = list(generate(target, source_type="zarr"))
+        if len(results) != 1:
+            raise PixelIdentityError(
+                "An explicit Zarr node must produce exactly one scene; "
+                f"iscc-bio returned {len(results)}"
+            )
+
+        result = results[0]
+        units = result.get("units")
+        if not isinstance(units, Sequence) or isinstance(units, (str, bytes)):
+            units = ()
+        if len(units) != 2:
+            raise PixelIdentityError(
+                "iscc-bio must return ordered Data and Instance code units"
+            )
+
+        try:
+            return PixelIdentity(
+                node_path=node_path,
+                role=role,
+                iscc_code=result["iscc_code"],
+                data_code=units[0],
+                instance_code=units[1],
+                tool_version=tool_version,
+                imagewalk_revision=(
+                    self._imagewalk_revision
+                    or f"iscc-bio/{tool_version}@{ISCC_BIO_GIT_REVISION}"
+                ),
+                shape=tuple(shape),
+                dtype=dtype,
+                axes=tuple(axes),
+                coordinate_transformations=tuple(
+                    dict(item) for item in coordinate_transformations
+                ),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise PixelIdentityError(
+                "iscc-bio returned an invalid pixel identity result"
+            ) from exc
+
+
+def pixel_identities_match(left: PixelIdentity, right: PixelIdentity) -> bool:
+    """Return whether exact bytes and their NGFF semantic guards agree.
+
+    Node paths and aggregate/data codes are intentionally excluded: a raw scene
+    and its canonical Zarr node can live at different paths, while the Instance
+    Code is the exact byte identity used for deduplication.
+    """
+    return (
+        left.instance_code == right.instance_code
+        and left.role == right.role
+        and left.shape == right.shape
+        and left.dtype == right.dtype
+        and left.axes == right.axes
+        and left.coordinate_transformations == right.coordinate_transformations
+    )
+
+
+__all__ = [
+    "IsccBioIdentityProvider",
+    "ISCC_BIO_GIT_REVISION",
+    "PixelIdentityError",
+    "pixel_identities_match",
+]

--- a/biomero_importer/utils/pixel_identity.py
+++ b/biomero_importer/utils/pixel_identity.py
@@ -5,12 +5,15 @@ module only selects one explicit image node, validates the public API result,
 and combines it with the semantic guard required by BIOMERO's shared contract.
 """
 
+from dataclasses import dataclass
 from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version
+import json
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Literal, Mapping, Sequence
 
 from biomero_schema.zarr import PixelIdentity
+import numpy as np
 
 
 BiocodeCallable = Callable[..., Sequence[Mapping[str, Any]]]
@@ -21,6 +24,18 @@ class PixelIdentityError(RuntimeError):
     """An exact pixel identity could not be calculated unambiguously."""
 
 
+@dataclass(frozen=True)
+class ZarrNodeSemanticGuard:
+    """Relevant metadata for the highest-resolution array of one NGFF node."""
+
+    shape: tuple[int, ...]
+    dtype: str
+    axes: tuple[str, ...]
+    coordinate_transformations: tuple[dict[str, Any], ...]
+    ngff_version: str
+    zarr_format: int
+
+
 def _validate_node_path(node_path: str) -> PurePosixPath:
     if not node_path or "\\" in node_path:
         raise PixelIdentityError(f"Unsafe Zarr node path: {node_path!r}")
@@ -28,6 +43,94 @@ def _validate_node_path(node_path: str) -> PurePosixPath:
     if parsed.is_absolute() or ".." in parsed.parts:
         raise PixelIdentityError(f"Unsafe Zarr node path: {node_path!r}")
     return parsed
+
+
+def _read_json_object(path: Path, description: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PixelIdentityError(
+            f"Cannot read {description} metadata: {path}"
+        ) from exc
+    if not isinstance(value, dict):
+        raise PixelIdentityError(f"Invalid {description} metadata: {path}")
+    return value
+
+
+def read_zarr_v2_semantic_guard(
+    zarr_root: str | Path, node_path: str
+) -> ZarrNodeSemanticGuard:
+    """Read the supported NGFF 0.4/Zarr v2 guard for one explicit image node."""
+    parsed_node = _validate_node_path(node_path)
+    node = Path(zarr_root)
+    if node_path != ".":
+        node = node.joinpath(*parsed_node.parts)
+
+    attributes = _read_json_object(node / ".zattrs", "NGFF image")
+    multiscales = attributes.get("multiscales")
+    if not isinstance(multiscales, list) or len(multiscales) != 1:
+        raise PixelIdentityError(
+            "NGFF image metadata must contain exactly one multiscales entry"
+        )
+    multiscale = multiscales[0]
+    if not isinstance(multiscale, dict) or multiscale.get("version") != "0.4":
+        raise PixelIdentityError("Only NGFF 0.4 image metadata is supported")
+
+    raw_axes = multiscale.get("axes")
+    if not isinstance(raw_axes, list) or not raw_axes:
+        raise PixelIdentityError("NGFF 0.4 image metadata has no named axes")
+    axes = []
+    for axis in raw_axes:
+        name = axis.get("name") if isinstance(axis, dict) else axis
+        if not isinstance(name, str) or not name:
+            raise PixelIdentityError("NGFF 0.4 image metadata has an invalid axis")
+        axes.append(name)
+
+    datasets = multiscale.get("datasets")
+    if not isinstance(datasets, list) or not datasets:
+        raise PixelIdentityError("NGFF 0.4 image metadata has no datasets")
+    highest_resolution = datasets[0]
+    if not isinstance(highest_resolution, dict):
+        raise PixelIdentityError("NGFF 0.4 dataset metadata is invalid")
+    dataset_path = highest_resolution.get("path")
+    if not isinstance(dataset_path, str):
+        raise PixelIdentityError("NGFF 0.4 dataset path is missing")
+    parsed_dataset = _validate_node_path(dataset_path)
+    array_path = node
+    if dataset_path != ".":
+        array_path = node.joinpath(*parsed_dataset.parts)
+
+    array = _read_json_object(array_path / ".zarray", "Zarr array")
+    if array.get("zarr_format") != 2:
+        raise PixelIdentityError("Only Zarr v2 arrays are supported")
+    shape = array.get("shape")
+    if (
+        not isinstance(shape, list)
+        or not shape
+        or any(not isinstance(size, int) or size < 1 for size in shape)
+    ):
+        raise PixelIdentityError("Zarr v2 array shape is invalid")
+    if len(shape) != len(axes):
+        raise PixelIdentityError("Zarr array shape does not match NGFF axes")
+    try:
+        dtype = np.dtype(array["dtype"]).name
+    except (KeyError, TypeError) as exc:
+        raise PixelIdentityError("Zarr v2 array dtype is invalid") from exc
+
+    transformations = highest_resolution.get("coordinateTransformations", [])
+    if not isinstance(transformations, list) or any(
+        not isinstance(item, dict) for item in transformations
+    ):
+        raise PixelIdentityError("NGFF coordinate transformations are invalid")
+
+    return ZarrNodeSemanticGuard(
+        shape=tuple(shape),
+        dtype=dtype,
+        axes=tuple(axes),
+        coordinate_transformations=tuple(dict(item) for item in transformations),
+        ngff_version="0.4",
+        zarr_format=2,
+    )
 
 
 class IsccBioIdentityProvider:
@@ -150,5 +253,7 @@ __all__ = [
     "IsccBioIdentityProvider",
     "ISCC_BIO_GIT_REVISION",
     "PixelIdentityError",
+    "ZarrNodeSemanticGuard",
     "pixel_identities_match",
+    "read_zarr_v2_semantic_guard",
 ]

--- a/biomero_importer/utils/pixel_identity.py
+++ b/biomero_importer/utils/pixel_identity.py
@@ -191,7 +191,12 @@ class IsccBioIdentityProvider:
             target = target.joinpath(*parsed_node.parts)
 
         generate, tool_version = self._load_upstream()
-        results = list(generate(target, source_type="zarr"))
+        # Use iscc-bio's BioIO IMAGEWALK implementation for explicit image
+        # nodes.  iscc-bio 0.1.0's direct NGFF reader mistakes the numeric
+        # pyramid arrays of a normal multiscale image for bioformats2raw
+        # series. BioIO follows the same upstream IMAGEWALK contract without
+        # duplicating hashing or traversal here.
+        results = list(generate(target, source_type="bioio"))
         return self._build_identity(
             results,
             source_description="An explicit Zarr node",

--- a/biomero_importer/utils/pixel_identity.py
+++ b/biomero_importer/utils/pixel_identity.py
@@ -192,9 +192,65 @@ class IsccBioIdentityProvider:
 
         generate, tool_version = self._load_upstream()
         results = list(generate(target, source_type="zarr"))
+        return self._build_identity(
+            results,
+            source_description="An explicit Zarr node",
+            tool_version=tool_version,
+            node_path=node_path,
+            role=role,
+            shape=shape,
+            dtype=dtype,
+            axes=axes,
+            coordinate_transformations=coordinate_transformations,
+        )
+
+    def generate_omero(
+        self,
+        connection: Any,
+        *,
+        image_id: int,
+        node_path: str,
+        role: Literal["image", "label"],
+        shape: Sequence[int],
+        dtype: str,
+        axes: Sequence[str],
+        coordinate_transformations: Sequence[Mapping[str, Any]] = (),
+    ) -> PixelIdentity:
+        """Hash one OMERO Image through the upstream Blitz IMAGEWALK reader."""
+        _validate_node_path(node_path)
+        if not isinstance(image_id, int) or isinstance(image_id, bool) or image_id < 1:
+            raise PixelIdentityError("OMERO image ID must be a positive integer")
+        generate, tool_version = self._load_upstream()
+        results = list(generate(conn=connection, iid=image_id))
+        return self._build_identity(
+            results,
+            source_description=f"OMERO Image {image_id}",
+            tool_version=tool_version,
+            node_path=node_path,
+            role=role,
+            shape=shape,
+            dtype=dtype,
+            axes=axes,
+            coordinate_transformations=coordinate_transformations,
+        )
+
+    def _build_identity(
+        self,
+        results: Sequence[Mapping[str, Any]],
+        *,
+        source_description: str,
+        tool_version: str,
+        node_path: str,
+        role: Literal["image", "label"],
+        shape: Sequence[int],
+        dtype: str,
+        axes: Sequence[str],
+        coordinate_transformations: Sequence[Mapping[str, Any]],
+    ) -> PixelIdentity:
+        """Validate one public API result and produce the shared contract."""
         if len(results) != 1:
             raise PixelIdentityError(
-                "An explicit Zarr node must produce exactly one scene; "
+                f"{source_description} must produce exactly one scene; "
                 f"iscc-bio returned {len(results)}"
             )
 

--- a/biomero_importer/utils/register.py
+++ b/biomero_importer/utils/register.py
@@ -20,6 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from urllib.parse import urlsplit
+from copy import copy
 import zarr
 from zarr.core.buffer import default_buffer_prototype
 from zarr.core.sync import sync
@@ -602,8 +603,42 @@ def register_plate(conn, store, args, attrs):
 
             img_attrs = load_attrs(store, image_path)
             image_name = img_attrs.get('name', f"{well_path}/{sample_attrs['path']}")
-
-            image, rnd_def = create_image(conn, store, img_attrs, image_name, families, models, args, image_path)
+            label_sources = getattr(args, "plate_label_paths", {})
+            label_name = getattr(args, "plate_label_name", None)
+            label_path = label_sources.get(image_path.rstrip("/"))
+            if label_name is not None and label_path is None:
+                raise ValueError(
+                    f"Plate image {image_path} has no mapped label "
+                    f"source for {label_name!r}"
+                )
+            if label_path is not None:
+                label_store = zarr.storage.LocalStore(
+                    str(label_path),
+                    read_only=True,
+                )
+                label_attrs = load_attrs(label_store)
+                label_args = copy(args)
+                label_args.uri = str(label_path)
+                image, rnd_def = create_image(
+                    conn,
+                    label_store,
+                    label_attrs,
+                    f"{image_name} [{label_name}]",
+                    families,
+                    models,
+                    label_args,
+                )
+            else:
+                image, rnd_def = create_image(
+                    conn,
+                    store,
+                    img_attrs,
+                    image_name,
+                    families,
+                    models,
+                    args,
+                    image_path,
+                )
 
             images_to_save.append(image)
             if rnd_def is not None:
@@ -844,4 +879,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/biomero_importer/utils/result_zarr.py
+++ b/biomero_importer/utils/result_zarr.py
@@ -939,14 +939,6 @@ def normalize_returned_zarr(
             "Returned identities no longer describe the discovered image nodes"
         )
     matched_input = decision.matched_inputs[0]
-    if (
-        matched_input.transfer_artifact is not None
-        and matched_input.transfer_artifact != root.name
-    ):
-        raise PixelIdentityError(
-            "Returned store name no longer matches its transferred artifact"
-        )
-
     if matched_input.plate_source is not None:
         input_sources = {
             image.image_node_path: image.source

--- a/biomero_importer/utils/result_zarr.py
+++ b/biomero_importer/utils/result_zarr.py
@@ -10,12 +10,17 @@ from dataclasses import dataclass
 import json
 import os
 from pathlib import Path, PurePosixPath
+import shutil
 from typing import Literal
+from uuid import UUID, uuid4
 
 from biomero_schema.zarr import (
     CanonicalInput,
     CanonicalInputManifest,
     PixelIdentity,
+    SHALLOW_COLLECTION_MANIFEST,
+    ShallowCollection,
+    ShallowImageReference,
 )
 
 from .pixel_identity import (
@@ -51,6 +56,16 @@ class ReturnedZarrDecision:
         return self.outcome == "eligible"
 
 
+@dataclass(frozen=True)
+class NormalizedShallowResult:
+    """Committed shallow collection and its measured storage reduction."""
+
+    store_path: Path
+    collection: ShallowCollection
+    bytes_before: int
+    bytes_after: int
+
+
 def _safe_node_path(value: str) -> str:
     if not value or "\\" in value:
         raise PixelIdentityError(f"Unsafe NGFF node path: {value!r}")
@@ -80,6 +95,15 @@ def _read_attrs(node: Path) -> dict:
     if not isinstance(value, dict):
         raise PixelIdentityError(f"Invalid NGFF attributes: {path}")
     return value
+
+
+def _write_json(path: Path, value: dict) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
 
 
 def _discover_labels(root: Path, image_node_path: str) -> list[NgffNode]:
@@ -207,6 +231,194 @@ def _identity_for_node(
     )
 
 
+def _declared_image_dataset_directories(
+    root: Path,
+    image_node_path: str,
+) -> tuple[Path, ...]:
+    image_node = _node_directory(root, image_node_path)
+    attrs = _read_attrs(image_node)
+    multiscales = attrs.get("multiscales")
+    if not isinstance(multiscales, list) or not multiscales:
+        raise PixelIdentityError(
+            f"NGFF image node has no multiscales metadata: {image_node_path}"
+        )
+    directories = []
+    for multiscale in multiscales:
+        datasets = (
+            multiscale.get("datasets")
+            if isinstance(multiscale, dict)
+            else None
+        )
+        if not isinstance(datasets, list) or not datasets:
+            raise PixelIdentityError(
+                f"NGFF multiscales has no datasets: {image_node_path}"
+            )
+        for dataset in datasets:
+            dataset_path = (
+                dataset.get("path") if isinstance(dataset, dict) else None
+            )
+            if not isinstance(dataset_path, str):
+                raise PixelIdentityError(
+                    f"NGFF dataset path is missing: {image_node_path}"
+                )
+            dataset_path = _safe_node_path(dataset_path)
+            directory = _node_directory(
+                root,
+                _join_node_path(image_node_path, dataset_path),
+            )
+            try:
+                directory.relative_to(root)
+            except ValueError as exc:
+                raise PixelIdentityError(
+                    f"NGFF dataset escapes its store: {dataset_path}"
+                ) from exc
+            directories.append(directory)
+    return tuple(dict.fromkeys(directories))
+
+
+def _tree_size(root: Path) -> int:
+    return sum(
+        path.stat().st_size
+        for path in root.rglob("*")
+        if path.is_file() and not path.is_symlink()
+    )
+
+
+def normalize_returned_zarr(
+    decision: ReturnedZarrDecision,
+    workflow_id: UUID | str,
+    *,
+    replace=os.replace,
+) -> NormalizedShallowResult:
+    """Transactionally omit a verified duplicate image from a result store.
+
+    A new sibling store is assembled from metadata and retained labels. Only
+    after that store and its manifest validate do atomic renames make it live.
+    The canonical source is never modified. Unsupported inputs raise before
+    the original result is moved.
+    """
+    if not decision.eligible or len(decision.matched_inputs) != 1:
+        raise PixelIdentityError("Returned Zarr is not eligible for shallowing")
+    if len(decision.image_identities) != 1:
+        raise PixelIdentityError("Expected exactly one returned image identity")
+
+    root = decision.store_path
+    if not root.is_dir():
+        raise PixelIdentityError(f"Returned Zarr does not exist: {root}")
+    nodes = discover_ngff_nodes(root)
+    image_nodes = tuple(node for node in nodes if node.role == "image")
+    label_nodes = tuple(node for node in nodes if node.role == "label")
+    if len(image_nodes) != 1 or not label_nodes:
+        raise PixelIdentityError(
+            "Only one-image returned stores with declared labels can be "
+            "normalized in this implementation"
+        )
+
+    image_node = image_nodes[0]
+    returned_identity = decision.image_identities[0]
+    if returned_identity.node_path != image_node.node_path:
+        raise PixelIdentityError(
+            "Returned identity no longer describes the discovered image node"
+        )
+    matched_input = decision.matched_inputs[0]
+    if matched_input.transfer_artifact != root.name:
+        raise PixelIdentityError(
+            "Returned store name no longer matches its transferred artifact"
+        )
+
+    collection = ShallowCollection(
+        workflow_id=UUID(str(workflow_id)),
+        transfer_artifact=root.name,
+        interchange_profile=matched_input.source.interchange_profile,
+        images=(ShallowImageReference(
+            image_node_path=image_node.node_path,
+            source=matched_input.source,
+            returned_pixel_identity=returned_identity,
+            label_node_paths=tuple(node.node_path for node in label_nodes),
+        ),),
+    )
+    omitted = set(_declared_image_dataset_directories(
+        root,
+        image_node.node_path,
+    ))
+    token = uuid4().hex
+    staging = root.with_name(f".{root.name}.biomero-stage-{token}")
+    backup = root.with_name(f".{root.name}.biomero-full-{token}")
+    bytes_before = _tree_size(root)
+
+    def ignore(directory, names):
+        current = Path(directory)
+        return {
+            name for name in names
+            if current / name in omitted
+        }
+
+    moved_original = False
+    committed = False
+    try:
+        shutil.copytree(root, staging, symlinks=True, ignore=ignore)
+        staging_attrs_path = _node_directory(
+            staging,
+            image_node.node_path,
+        ) / ".zattrs"
+        staging_attrs = _read_attrs(staging_attrs_path.parent)
+        staging_attrs.pop("multiscales", None)
+        staging_attrs["biomero"] = {
+            "model": collection.model,
+            "manifest": SHALLOW_COLLECTION_MANIFEST,
+            "workflowId": str(collection.workflow_id),
+        }
+        _write_json(staging_attrs_path, staging_attrs)
+        _write_json(
+            staging / SHALLOW_COLLECTION_MANIFEST,
+            collection.to_dict(),
+        )
+
+        validated = ShallowCollection.from_dict(json.loads(
+            (staging / SHALLOW_COLLECTION_MANIFEST).read_text(
+                encoding="utf-8"
+            )
+        ))
+        if validated != collection:
+            raise PixelIdentityError("Shallow collection manifest changed")
+        for label in label_nodes:
+            label_dir = _node_directory(staging, label.node_path)
+            if not label_dir.is_dir():
+                raise PixelIdentityError(
+                    f"Staged shallow result lost label node {label.node_path}"
+                )
+        for dataset in omitted:
+            staged_dataset = staging / dataset.relative_to(root)
+            if staged_dataset.exists():
+                raise PixelIdentityError(
+                    f"Staged shallow result retained image dataset {dataset}"
+                )
+
+        replace(root, backup)
+        moved_original = True
+        try:
+            replace(staging, root)
+            committed = True
+        except Exception:
+            replace(backup, root)
+            moved_original = False
+            raise
+        bytes_after = _tree_size(root)
+        shutil.rmtree(backup)
+        moved_original = False
+        return NormalizedShallowResult(
+            store_path=root,
+            collection=collection,
+            bytes_before=bytes_before,
+            bytes_after=bytes_after,
+        )
+    finally:
+        if staging.exists():
+            shutil.rmtree(staging, ignore_errors=True)
+        if moved_original and not committed and backup.exists() and not root.exists():
+            replace(backup, root)
+
+
 def evaluate_returned_zarr(
     zarr_root: str | Path,
     canonical_inputs: CanonicalInputManifest | None,
@@ -309,8 +521,10 @@ def evaluate_returned_zarr(
 
 __all__ = [
     "NgffNode",
+    "NormalizedShallowResult",
     "ReturnedZarrDecision",
     "discover_ngff_nodes",
     "evaluate_returned_zarr",
     "find_returned_zarr_stores",
+    "normalize_returned_zarr",
 ]

--- a/biomero_importer/utils/result_zarr.py
+++ b/biomero_importer/utils/result_zarr.py
@@ -700,6 +700,15 @@ def normalize_returned_zarr(
         root,
         image_node.node_path,
     ))
+    inherited_label_paths = {
+        component.logical_node_path
+        for component in decision.label_components
+        if component.source is not None
+    }
+    omitted.update(
+        _node_directory(root, label_path)
+        for label_path in inherited_label_paths
+    )
     token = uuid4().hex
     staging = root.with_name(f".{root.name}.biomero-stage-{token}")
     backup = root.with_name(f".{root.name}.biomero-full-{token}")
@@ -742,7 +751,13 @@ def normalize_returned_zarr(
             raise PixelIdentityError("Shallow collection manifest changed")
         for label in label_nodes:
             label_dir = _node_directory(staging, label.node_path)
-            if not label_dir.is_dir():
+            if label.node_path in inherited_label_paths:
+                if label_dir.exists():
+                    raise PixelIdentityError(
+                        f"Staged shallow result retained inherited label "
+                        f"{label.node_path}"
+                    )
+            elif not label_dir.is_dir():
                 raise PixelIdentityError(
                     f"Staged shallow result lost label node {label.node_path}"
                 )

--- a/biomero_importer/utils/result_zarr.py
+++ b/biomero_importer/utils/result_zarr.py
@@ -6,7 +6,9 @@ caller can therefore run it in keep-only mode and safely retain every result
 when discovery or identity matching is incomplete.
 """
 
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from functools import partial
 import json
 import os
 from pathlib import Path, PurePosixPath
@@ -859,6 +861,30 @@ def _identity_for_node(
     )
 
 
+def _identities_for_nodes(
+    root: Path,
+    nodes: tuple[NgffNode, ...],
+    identity_provider: IsccBioIdentityProvider,
+    *,
+    max_workers: int = 1,
+) -> tuple[PixelIdentity, ...]:
+    """Generate identities in node order with optional bounded concurrency."""
+    if isinstance(max_workers, bool) or not isinstance(max_workers, int):
+        raise ValueError("Identity workers must be a positive integer")
+    if max_workers < 1:
+        raise ValueError("Identity workers must be a positive integer")
+    generate = partial(_identity_for_node, root, identity_provider=identity_provider)
+    if max_workers == 1 or len(nodes) < 2:
+        return tuple(generate(node) for node in nodes)
+    with ThreadPoolExecutor(
+        max_workers=min(max_workers, len(nodes)),
+        thread_name_prefix="biomero-iscc",
+    ) as executor:
+        # executor.map preserves the discovered node order even when workers
+        # finish out of order, keeping manifests and comparisons deterministic.
+        return tuple(executor.map(generate, nodes))
+
+
 def _declared_image_dataset_directories(
     root: Path,
     image_node_path: str,
@@ -1135,6 +1161,7 @@ def evaluate_returned_zarr(
     canonical_inputs: CanonicalInputManifest | None,
     *,
     identity_provider: IsccBioIdentityProvider | None = None,
+    identity_workers: int = 1,
 ) -> ReturnedZarrDecision:
     """Compare one returned image store with its workflow-scoped inputs.
 
@@ -1142,6 +1169,12 @@ def evaluate_returned_zarr(
     store, which makes failures and unsupported cases unconditionally fail
     open to ``keep-full``.
     """
+    if (
+        isinstance(identity_workers, bool)
+        or not isinstance(identity_workers, int)
+        or identity_workers < 1
+    ):
+        raise ValueError("Identity workers must be a positive integer")
     root = Path(zarr_root)
     if canonical_inputs is None or not canonical_inputs.inputs:
         return ReturnedZarrDecision(
@@ -1170,9 +1203,11 @@ def evaluate_returned_zarr(
         )
     provider = identity_provider or IsccBioIdentityProvider()
     try:
-        returned_identities = tuple(
-            _identity_for_node(root, node, provider)
-            for node in image_nodes
+        returned_identities = _identities_for_nodes(
+            root,
+            image_nodes,
+            provider,
+            max_workers=identity_workers,
         )
     except PixelIdentityError as exc:
         return ReturnedZarrDecision(
@@ -1257,10 +1292,11 @@ def evaluate_returned_zarr(
         )
 
     try:
-        label_identities = tuple(
-            _identity_for_node(root, node, provider)
-            for node in nodes
-            if node.role == "label"
+        label_identities = _identities_for_nodes(
+            root,
+            tuple(node for node in nodes if node.role == "label"),
+            provider,
+            max_workers=identity_workers,
         )
     except PixelIdentityError as exc:
         return ReturnedZarrDecision(

--- a/biomero_importer/utils/result_zarr.py
+++ b/biomero_importer/utils/result_zarr.py
@@ -17,6 +17,7 @@ from uuid import UUID, uuid4
 from biomero_schema.zarr import (
     CanonicalInput,
     CanonicalInputManifest,
+    ManagedZarrNode,
     PixelIdentity,
     SHALLOW_COLLECTION_MANIFEST,
     ShallowCollection,
@@ -82,6 +83,15 @@ class ShallowRegistration:
     registration_path: Path
     reference: ShallowZarrReference
     kind: Literal["primary", "label"]
+
+
+@dataclass(frozen=True)
+class MaterializedShallowResult:
+    """A full temporary workflow input reconstructed from managed components."""
+
+    destination: Path
+    collection: ShallowCollection
+    labels: tuple[ZarrLabelComponent, ...]
 
 
 def _safe_node_path(value: str) -> str:
@@ -303,6 +313,155 @@ def resolve_shallow_registration(
         registration_path=registration_path,
         reference=reference,
         kind=kind,
+    )
+
+
+def materialize_shallow_zarr(
+    reference: ShallowZarrReference,
+    destination: str | Path,
+    storage_roots: dict[str, Path],
+    *,
+    identity_provider: IsccBioIdentityProvider | None = None,
+    replace=os.replace,
+) -> MaterializedShallowResult:
+    """Build a conventional image-plus-label Zarr from a shallow reference.
+
+    The managed source and collections are read-only. The destination is
+    assembled as a sibling staging directory and atomically renamed only after
+    every declared label has been copied and its stable source recorded.
+    """
+    destination = Path(destination)
+    if destination.exists():
+        raise PixelIdentityError(
+            f"Shallow materialization destination already exists: {destination}"
+        )
+    collection_root = resolve_managed_source_path(reference, storage_roots)
+    manifest_path = collection_root / SHALLOW_COLLECTION_MANIFEST
+    try:
+        collection = ShallowCollection.from_dict(json.loads(
+            manifest_path.read_text(encoding="utf-8")
+        ))
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise PixelIdentityError(
+            f"Invalid shallow collection manifest: {manifest_path}"
+        ) from exc
+    matches = [
+        image for image in collection.images
+        if image.image_node_path == reference.image_node_path
+    ]
+    if len(matches) != 1:
+        raise PixelIdentityError(
+            "Shallow reference must identify exactly one collection image"
+        )
+    image = matches[0]
+    if (
+        image.source != reference.source
+        or set(image.label_node_paths) != set(reference.label_node_paths)
+    ):
+        raise PixelIdentityError(
+            "Shallow reference no longer matches its collection manifest"
+        )
+    if image.image_node_path != "." or image.source.node_path != ".":
+        raise PixelIdentityError(
+            "Materialization currently supports one root-level NGFF image"
+        )
+
+    canonical_root = resolve_managed_source_path(image.source, storage_roots)
+    provider = identity_provider or IsccBioIdentityProvider()
+    components = image.label_components
+    if not components:
+        discovered = {
+            node.node_path: node
+            for node in discover_ngff_nodes(collection_root)
+            if node.role == "label"
+        }
+        legacy_components = []
+        for logical_path in image.label_node_paths:
+            node = discovered.get(logical_path)
+            if node is None:
+                raise PixelIdentityError(
+                    f"Legacy shallow collection lost label {logical_path}"
+                )
+            identity = _identity_for_node(collection_root, node, provider)
+            legacy_components.append(ZarrLabelComponent(
+                logical_node_path=logical_path,
+                pixel_identity=identity,
+            ))
+        components = tuple(legacy_components)
+
+    token = uuid4().hex
+    staging = destination.with_name(
+        f".{destination.name}.biomero-materialize-{token}"
+    )
+    source_labels = canonical_root / "labels"
+
+    def ignore(directory, names):
+        current = Path(directory)
+        ignored = {".biomero-canonical.json"}.intersection(names)
+        if current == canonical_root and source_labels.name in names:
+            ignored.add(source_labels.name)
+        return ignored
+
+    managed_labels = []
+    try:
+        shutil.copytree(canonical_root, staging, symlinks=True, ignore=ignore)
+        labels_root = staging / "labels"
+        labels_root.mkdir(parents=True, exist_ok=False)
+        _write_json(labels_root / ".zgroup", {"zarr_format": 2})
+        label_names = []
+        for component in components:
+            prefix = PurePosixPath("labels")
+            logical = PurePosixPath(component.logical_node_path)
+            try:
+                label_name = logical.relative_to(prefix).as_posix()
+            except ValueError as exc:
+                raise PixelIdentityError(
+                    "Root-image label paths must be nested below labels/"
+                ) from exc
+            label_names.append(label_name)
+            if component.source is None:
+                physical_root = collection_root
+                physical_node = component.logical_node_path
+                managed_source = ManagedZarrNode(
+                    storage_root=reference.storage_root,
+                    relative_path=reference.relative_path,
+                    node_path=component.logical_node_path,
+                )
+            else:
+                physical_root = resolve_managed_source_path(
+                    component.source,
+                    storage_roots,
+                )
+                physical_node = component.source.node_path
+                managed_source = component.source
+            physical_path = _node_directory(physical_root, physical_node)
+            if not physical_path.is_dir():
+                raise PixelIdentityError(
+                    f"Managed shallow label is unavailable: {physical_path}"
+                )
+            target = _node_directory(staging, component.logical_node_path)
+            shutil.copytree(physical_path, target, symlinks=True)
+            managed_labels.append(component.model_copy(update={
+                "source": managed_source,
+            }))
+        _write_json(labels_root / ".zattrs", {"labels": label_names})
+        discovered_paths = {
+            node.node_path for node in discover_ngff_nodes(staging)
+            if node.role == "label"
+        }
+        if discovered_paths != set(image.label_node_paths):
+            raise PixelIdentityError(
+                "Materialized label inventory differs from shallow collection"
+            )
+        replace(staging, destination)
+    finally:
+        if staging.exists():
+            shutil.rmtree(staging, ignore_errors=True)
+
+    return MaterializedShallowResult(
+        destination=destination,
+        collection=collection,
+        labels=tuple(managed_labels),
     )
 
 
@@ -768,6 +927,7 @@ def evaluate_returned_zarr(
 
 __all__ = [
     "NgffNode",
+    "MaterializedShallowResult",
     "NormalizedShallowResult",
     "ReturnedZarrDecision",
     "ShallowRegistration",
@@ -775,6 +935,7 @@ __all__ = [
     "evaluate_returned_zarr",
     "find_returned_zarr_stores",
     "load_managed_storage_roots",
+    "materialize_shallow_zarr",
     "normalize_returned_zarr",
     "resolve_managed_source_path",
     "resolve_shallow_registration",

--- a/biomero_importer/utils/result_zarr.py
+++ b/biomero_importer/utils/result_zarr.py
@@ -22,6 +22,7 @@ from biomero_schema.zarr import (
     ShallowCollection,
     ShallowImageReference,
     ShallowZarrReference,
+    ZarrLabelComponent,
 )
 
 from .pixel_identity import (
@@ -49,6 +50,8 @@ class ReturnedZarrDecision:
     outcome: Literal["eligible", "keep-full", "skip-passthrough"]
     reason: str
     image_identities: tuple[PixelIdentity, ...] = ()
+    label_identities: tuple[PixelIdentity, ...] = ()
+    label_components: tuple[ZarrLabelComponent, ...] = ()
     label_node_paths: tuple[str, ...] = ()
     matched_inputs: tuple[CanonicalInput, ...] = ()
 
@@ -532,6 +535,7 @@ def normalize_returned_zarr(
             source=matched_input.source,
             returned_pixel_identity=returned_identity,
             label_node_paths=tuple(node.node_path for node in label_nodes),
+            label_components=decision.label_components,
         ),),
     )
     omitted = set(_declared_image_dataset_directories(
@@ -707,14 +711,58 @@ def evaluate_returned_zarr(
             image_identities=(returned_identity,),
             matched_inputs=matches,
         )
-    eligible = unchanged and bool(label_paths)
+    if not unchanged or not label_paths:
+        return ReturnedZarrDecision(
+            store_path=root,
+            outcome="keep-full",
+            reason=reason,
+            image_identities=(returned_identity,),
+            label_node_paths=label_paths,
+        )
+
+    try:
+        label_identities = tuple(
+            _identity_for_node(root, node, provider)
+            for node in nodes
+            if node.role == "label"
+        )
+    except PixelIdentityError as exc:
+        return ReturnedZarrDecision(
+            store_path=root,
+            outcome="keep-full",
+            reason=f"label-identity-unavailable: {exc}",
+            image_identities=(returned_identity,),
+            label_node_paths=label_paths,
+        )
+
+    input_labels = {
+        label.logical_node_path: label
+        for label in matches[0].labels
+    }
+    label_components = []
+    for identity in label_identities:
+        inherited = input_labels.get(identity.node_path)
+        source = None
+        if inherited is not None and pixel_identities_match(
+            identity,
+            inherited.pixel_identity,
+        ):
+            source = inherited.source
+        label_components.append(ZarrLabelComponent(
+            logical_node_path=identity.node_path,
+            pixel_identity=identity,
+            source=source,
+        ))
+
     return ReturnedZarrDecision(
         store_path=root,
-        outcome="eligible" if eligible else "keep-full",
+        outcome="eligible",
         reason=reason,
         image_identities=(returned_identity,),
+        label_identities=label_identities,
+        label_components=tuple(label_components),
         label_node_paths=label_paths,
-        matched_inputs=matches if eligible else (),
+        matched_inputs=matches,
     )
 
 

--- a/biomero_importer/utils/result_zarr.py
+++ b/biomero_importer/utils/result_zarr.py
@@ -69,12 +69,12 @@ class ReturnedZarrDecision:
 
 @dataclass(frozen=True)
 class NormalizedShallowResult:
-    """Committed shallow collection and its measured storage reduction."""
+    """Committed shallow collection and optional storage measurements."""
 
     store_path: Path
     collection: ShallowCollection
-    bytes_before: int
-    bytes_after: int
+    bytes_before: int | None
+    bytes_after: int | None
 
 
 @dataclass(frozen=True)
@@ -135,6 +135,13 @@ def _write_json(path: Path, value: dict) -> None:
         json.dumps(value, indent=2, sort_keys=True),
         encoding="utf-8",
     )
+    os.replace(temporary, path)
+
+
+def _write_bytes(path: Path, value: bytes) -> None:
+    """Atomically restore file content used by normalization rollback."""
+    temporary = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    temporary.write_bytes(value)
     os.replace(temporary, path)
 
 
@@ -910,13 +917,21 @@ def normalize_returned_zarr(
     workflow_id: UUID | str,
     *,
     replace=os.replace,
+    measure_bytes: bool = False,
 ) -> NormalizedShallowResult:
-    """Transactionally omit a verified duplicate image from a result store.
+    """Transactionally omit verified duplicate arrays from a result store.
 
-    A new sibling store is assembled from metadata and retained labels. Only
-    after that store and its manifest validate do atomic renames make it live.
-    The canonical source is never modified. Unsupported inputs raise before
-    the original result is moved.
+    Duplicate image arrays are atomically moved into a sibling rollback
+    journal.  Labels and metadata stay in place, avoiding a costly copy of the
+    retained side of a large Plate.  The manifest is committed only after all
+    moves and metadata updates validate.  Any pre-commit failure restores the
+    original attributes and moves every array back.  The canonical source is
+    never modified.
+
+    Exact byte measurement is disabled by default because recursively stating
+    every file in a Plate can dominate the complete transaction on a mounted
+    filesystem.  ``measure_bytes`` is intended for diagnostics and benchmarks,
+    not the interactive import path.
     """
     if not decision.eligible or len(decision.matched_inputs) != 1:
         raise PixelIdentityError("Returned Zarr is not eligible for shallowing")
@@ -1006,27 +1021,50 @@ def normalize_returned_zarr(
         _node_directory(root, label_path)
         for label_path in inherited_label_paths
     )
+    # Moving whole Zarr array directories on one filesystem is metadata-only.
+    # Keep only top-level omitted directories so a future nested declaration
+    # cannot cause the same subtree to be moved twice.
+    minimal_omitted = []
+    for directory in sorted(
+        omitted,
+        key=lambda path: len(path.relative_to(root).parts),
+    ):
+        if not any(
+            directory.is_relative_to(parent)
+            for parent in minimal_omitted
+        ):
+            minimal_omitted.append(directory)
+
     token = uuid4().hex
-    staging = root.with_name(f".{root.name}.biomero-stage-{token}")
-    backup = root.with_name(f".{root.name}.biomero-full-{token}")
-    bytes_before = _tree_size(root)
+    rollback = root.with_name(f".{root.name}.biomero-prune-{token}")
+    bytes_before = _tree_size(root) if measure_bytes else None
+    manifest_path = root / SHALLOW_COLLECTION_MANIFEST
+    if manifest_path.exists():
+        raise PixelIdentityError(
+            f"Returned store already has {SHALLOW_COLLECTION_MANIFEST}"
+        )
 
-    def ignore(directory, names):
-        current = Path(directory)
-        return {
-            name for name in names
-            if current / name in omitted
-        }
-
-    moved_original = False
-    committed = False
+    moved_directories = []
+    original_attrs = {}
     try:
-        shutil.copytree(root, staging, symlinks=True, ignore=ignore)
+        rollback.mkdir()
+        for directory in minimal_omitted:
+            if not directory.is_dir():
+                raise PixelIdentityError(
+                    f"Returned array disappeared before normalization: "
+                    f"{directory}"
+                )
+            target = rollback / directory.relative_to(root)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            replace(directory, target)
+            moved_directories.append((directory, target))
+
         for image_node in image_nodes:
             staging_attrs_path = _node_directory(
-                staging,
+                root,
                 image_node.node_path,
             ) / ".zattrs"
+            original_attrs[staging_attrs_path] = staging_attrs_path.read_bytes()
             staging_attrs = _read_attrs(staging_attrs_path.parent)
             staging_attrs.pop("multiscales", None)
             staging_attrs["biomero"] = {
@@ -1036,19 +1074,19 @@ def normalize_returned_zarr(
             }
             _write_json(staging_attrs_path, staging_attrs)
         _write_json(
-            staging / SHALLOW_COLLECTION_MANIFEST,
+            manifest_path,
             collection.to_dict(),
         )
 
         validated = ShallowCollection.from_dict(json.loads(
-            (staging / SHALLOW_COLLECTION_MANIFEST).read_text(
+            manifest_path.read_text(
                 encoding="utf-8"
             )
         ))
         if validated != collection:
             raise PixelIdentityError("Shallow collection manifest changed")
         for label in label_nodes:
-            label_dir = _node_directory(staging, label.node_path)
+            label_dir = _node_directory(root, label.node_path)
             if label.node_path in inherited_label_paths:
                 if label_dir.exists():
                     raise PixelIdentityError(
@@ -1060,35 +1098,36 @@ def normalize_returned_zarr(
                     f"Staged shallow result lost label node {label.node_path}"
                 )
         for dataset in omitted:
-            staged_dataset = staging / dataset.relative_to(root)
-            if staged_dataset.exists():
+            if dataset.exists():
                 raise PixelIdentityError(
-                    f"Staged shallow result retained image dataset {dataset}"
+                    f"Shallow result retained image dataset {dataset}"
                 )
+        bytes_after = _tree_size(root) if measure_bytes else None
+    except Exception:
+        # Restore metadata before the arrays so readers never see valid
+        # multiscales pointing at only a partially restored pyramid.
+        if manifest_path.exists():
+            manifest_path.unlink()
+        for path, value in original_attrs.items():
+            _write_bytes(path, value)
+        for original, target in reversed(moved_directories):
+            original.parent.mkdir(parents=True, exist_ok=True)
+            if target.exists():
+                replace(target, original)
+        if rollback.exists():
+            shutil.rmtree(rollback, ignore_errors=True)
+        raise
 
-        replace(root, backup)
-        moved_original = True
-        try:
-            replace(staging, root)
-            committed = True
-        except Exception:
-            replace(backup, root)
-            moved_original = False
-            raise
-        bytes_after = _tree_size(root)
-        shutil.rmtree(backup)
-        moved_original = False
-        return NormalizedShallowResult(
-            store_path=root,
-            collection=collection,
-            bytes_before=bytes_before,
-            bytes_after=bytes_after,
-        )
-    finally:
-        if staging.exists():
-            shutil.rmtree(staging, ignore_errors=True)
-        if moved_original and not committed and backup.exists() and not root.exists():
-            replace(backup, root)
+    # Validation is the commit boundary. Cleanup only unlinks verified
+    # duplicate pixels, so it must not attempt a rollback after a partial
+    # filesystem deletion.
+    shutil.rmtree(rollback)
+    return NormalizedShallowResult(
+        store_path=root,
+        collection=collection,
+        bytes_before=bytes_before,
+        bytes_after=bytes_after,
+    )
 
 
 def evaluate_returned_zarr(

--- a/biomero_importer/utils/result_zarr.py
+++ b/biomero_importer/utils/result_zarr.py
@@ -22,7 +22,9 @@ from biomero_schema.zarr import (
     SHALLOW_COLLECTION_MANIFEST,
     ShallowCollection,
     ShallowImageReference,
+    ShallowPlateReference,
     ShallowZarrReference,
+    ZarrImportOptions,
     ZarrLabelComponent,
 )
 
@@ -81,8 +83,10 @@ class ShallowRegistration:
 
     collection_root: Path
     registration_path: Path
-    reference: ShallowZarrReference
-    kind: Literal["primary", "label"]
+    reference: ShallowZarrReference | ShallowPlateReference
+    kind: Literal["primary", "label", "plate"]
+    plate_label_paths: tuple[tuple[str, Path], ...] = ()
+    plate_label_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -227,6 +231,7 @@ def resolve_shallow_registration(
     *,
     storage_roots: dict[str, Path] | None = None,
     import_mount_path: str | Path | None = None,
+    import_options: ZarrImportOptions | dict | None = None,
 ) -> ShallowRegistration | None:
     """Resolve a primary shallow result or one of its label projections."""
     path = Path(zarr_path).resolve()
@@ -263,14 +268,88 @@ def resolve_shallow_registration(
             f"Invalid shallow collection manifest: {collection_root}"
         ) from exc
 
+    options = (
+        import_options
+        if isinstance(import_options, ZarrImportOptions)
+        else ZarrImportOptions.from_dict(import_options or {})
+    )
+    roots = storage_roots or load_managed_storage_roots(
+        import_mount_path=import_root
+    )
     relative_node = (
         "." if path == collection_root
         else path.relative_to(collection_root).as_posix()
     )
     if relative_node == ".":
-        if len(collection.images) != 1:
+        source_types = {
+            image.source.source_object_type for image in collection.images
+        }
+        if source_types == {"Plate"}:
+            reference = ShallowPlateReference.from_collection(
+                collection,
+                storage_root="import-mount-data",
+                relative_path=collection_root.relative_to(
+                    import_root
+                ).as_posix(),
+            )
+            first_source = collection.images[0].source
+            registration_path = resolve_managed_source_path(
+                first_source,
+                roots,
+            )
+            plate_label_paths = []
+            if options.plate_pixel_source == "label":
+                label_name = options.plate_label_name
+                for plate_image in collection.images:
+                    logical_path = _join_node_path(
+                        plate_image.image_node_path,
+                        "labels",
+                        label_name,
+                    )
+                    components = [
+                        component
+                        for component in plate_image.label_components
+                        if component.logical_node_path == logical_path
+                    ]
+                    if len(components) != 1:
+                        raise PixelIdentityError(
+                            f"Plate image {plate_image.image_node_path} does "
+                            f"not declare label {label_name!r} exactly once"
+                        )
+                    component = components[0]
+                    if component.source is None:
+                        physical_path = _node_directory(
+                            collection_root,
+                            logical_path,
+                        )
+                    else:
+                        physical_root = resolve_managed_source_path(
+                            component.source,
+                            roots,
+                        )
+                        physical_path = _node_directory(
+                            physical_root,
+                            component.source.node_path,
+                        )
+                    if not physical_path.is_dir():
+                        raise PixelIdentityError(
+                            f"Plate label is unavailable: {physical_path}"
+                        )
+                    plate_label_paths.append((
+                        plate_image.image_node_path,
+                        physical_path,
+                    ))
+            return ShallowRegistration(
+                collection_root=collection_root,
+                registration_path=registration_path,
+                reference=reference,
+                kind="plate",
+                plate_label_paths=tuple(plate_label_paths),
+                plate_label_name=options.plate_label_name,
+            )
+        if len(collection.images) != 1 or source_types != {"Image"}:
             raise PixelIdentityError(
-                "Primary registration currently requires one shallow image node"
+                "Primary registration requires one Image or one Plate source"
             )
         image = collection.images[0]
         kind = "primary"
@@ -295,9 +374,6 @@ def resolve_shallow_registration(
     if kind == "label":
         registration_path = path
     else:
-        roots = storage_roots or load_managed_storage_roots(
-            import_mount_path=import_root
-        )
         registration_path = resolve_managed_source_path(image.source, roots)
         if image.source.node_path != ".":
             registration_path = _node_directory(

--- a/biomero_importer/utils/result_zarr.py
+++ b/biomero_importer/utils/result_zarr.py
@@ -393,19 +393,28 @@ def resolve_shallow_registration(
 
 
 def materialize_shallow_zarr(
-    reference: ShallowZarrReference,
+    reference: ShallowZarrReference | ShallowPlateReference,
     destination: str | Path,
     storage_roots: dict[str, Path],
     *,
     identity_provider: IsccBioIdentityProvider | None = None,
     replace=os.replace,
 ) -> MaterializedShallowResult:
-    """Build a conventional image-plus-label Zarr from a shallow reference.
+    """Build a conventional image or Plate Zarr from a shallow reference.
 
     The managed source and collections are read-only. The destination is
     assembled as a sibling staging directory and atomically renamed only after
     every declared label has been copied and its stable source recorded.
     """
+    if isinstance(reference, ShallowPlateReference):
+        return _materialize_shallow_plate_zarr(
+            reference,
+            destination,
+            storage_roots,
+            identity_provider=identity_provider,
+            replace=replace,
+        )
+
     destination = Path(destination)
     if destination.exists():
         raise PixelIdentityError(
@@ -541,6 +550,170 @@ def materialize_shallow_zarr(
         if discovered_paths != expected_paths:
             raise PixelIdentityError(
                 "Materialized label inventory differs from shallow collection"
+            )
+        replace(staging, destination)
+    finally:
+        if staging.exists():
+            shutil.rmtree(staging, ignore_errors=True)
+
+    return MaterializedShallowResult(
+        destination=destination,
+        collection=collection,
+        labels=tuple(managed_labels),
+    )
+
+
+def _materialize_shallow_plate_zarr(
+    reference: ShallowPlateReference,
+    destination: str | Path,
+    storage_roots: dict[str, Path],
+    *,
+    identity_provider: IsccBioIdentityProvider | None = None,
+    replace=os.replace,
+) -> MaterializedShallowResult:
+    """Reconstruct one conventional Plate from its canonical pixels and labels."""
+    destination = Path(destination)
+    if destination.exists():
+        raise PixelIdentityError(
+            f"Shallow materialization destination already exists: {destination}"
+        )
+    collection_root = resolve_managed_source_path(reference, storage_roots)
+    manifest_path = collection_root / SHALLOW_COLLECTION_MANIFEST
+    try:
+        collection = ShallowCollection.from_dict(json.loads(
+            manifest_path.read_text(encoding="utf-8")
+        ))
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise PixelIdentityError(
+            f"Invalid shallow collection manifest: {manifest_path}"
+        ) from exc
+    try:
+        expected_reference = ShallowPlateReference.from_collection(
+            collection,
+            storage_root=reference.storage_root,
+            relative_path=reference.relative_path,
+        )
+    except ValueError as exc:
+        raise PixelIdentityError(
+            "Shallow Plate collection has inconsistent canonical sources"
+        ) from exc
+    if expected_reference != reference:
+        raise PixelIdentityError(
+            "Shallow Plate reference no longer matches its collection manifest"
+        )
+
+    first_source = collection.images[0].source
+    canonical_root = resolve_managed_source_path(first_source, storage_roots)
+    canonical_image_directories = {
+        _node_directory(canonical_root, image.source.node_path)
+        for image in collection.images
+    }
+    for directory in canonical_image_directories:
+        if not directory.is_dir():
+            raise PixelIdentityError(
+                f"Shallow Plate source image node is unavailable: {directory}"
+            )
+
+    token = uuid4().hex
+    staging = destination.with_name(
+        f".{destination.name}.biomero-materialize-{token}"
+    )
+    provider = identity_provider or IsccBioIdentityProvider()
+
+    def ignore(directory, names):
+        current = Path(directory)
+        ignored = {".biomero-canonical.json"}.intersection(names)
+        if current in canonical_image_directories and "labels" in names:
+            ignored.add("labels")
+        return ignored
+
+    managed_labels = []
+    expected_label_paths = set()
+    try:
+        shutil.copytree(canonical_root, staging, symlinks=True, ignore=ignore)
+        for image in collection.images:
+            components = image.label_components
+            if not components:
+                legacy_components = []
+                for logical_path in image.label_node_paths:
+                    physical_path = _node_directory(collection_root, logical_path)
+                    if not physical_path.is_dir():
+                        raise PixelIdentityError(
+                            f"Legacy shallow Plate lost label {logical_path}"
+                        )
+                    node = NgffNode(
+                        node_path=logical_path,
+                        role="label",
+                        parent_image_node_path=image.image_node_path,
+                    )
+                    legacy_components.append(ZarrLabelComponent(
+                        logical_node_path=logical_path,
+                        pixel_identity=_identity_for_node(
+                            collection_root, node, provider
+                        ),
+                    ))
+                components = tuple(legacy_components)
+
+            labels_root = _node_directory(
+                staging,
+                _join_node_path(image.image_node_path, "labels"),
+            )
+            labels_root.mkdir()
+            _write_json(labels_root / ".zgroup", {"zarr_format": 2})
+            label_names = []
+            prefix = PurePosixPath(
+                _join_node_path(image.image_node_path, "labels")
+            )
+            for component in sorted(
+                components, key=lambda item: item.logical_node_path
+            ):
+                logical = PurePosixPath(component.logical_node_path)
+                try:
+                    relative = logical.relative_to(prefix)
+                except ValueError as exc:
+                    raise PixelIdentityError(
+                        "Plate label paths must be nested below their image labels/"
+                    ) from exc
+                if len(relative.parts) != 1:
+                    raise PixelIdentityError(
+                        "Plate labels must have one name below the image labels/ group"
+                    )
+                label_names.append(relative.name)
+                expected_label_paths.add(component.logical_node_path)
+                if component.source is None:
+                    physical_root = collection_root
+                    physical_node = component.logical_node_path
+                    managed_source = ManagedZarrNode(
+                        storage_root=reference.storage_root,
+                        relative_path=reference.relative_path,
+                        node_path=component.logical_node_path,
+                    )
+                else:
+                    physical_root = resolve_managed_source_path(
+                        component.source,
+                        storage_roots,
+                    )
+                    physical_node = component.source.node_path
+                    managed_source = component.source
+                physical_path = _node_directory(physical_root, physical_node)
+                if not physical_path.is_dir():
+                    raise PixelIdentityError(
+                        f"Managed shallow Plate label is unavailable: {physical_path}"
+                    )
+                target = _node_directory(staging, component.logical_node_path)
+                shutil.copytree(physical_path, target, symlinks=True)
+                managed_labels.append(component.model_copy(update={
+                    "source": managed_source,
+                }))
+            _write_json(labels_root / ".zattrs", {"labels": label_names})
+
+        discovered_label_paths = {
+            node.node_path for node in discover_ngff_nodes(staging)
+            if node.role == "label"
+        }
+        if discovered_label_paths != expected_label_paths:
+            raise PixelIdentityError(
+                "Materialized Plate label inventory differs from shallow collection"
             )
         replace(staging, destination)
     finally:

--- a/biomero_importer/utils/result_zarr.py
+++ b/biomero_importer/utils/result_zarr.py
@@ -1,0 +1,316 @@
+"""Discover and compare returned NGFF stores without mutating them.
+
+This module is the decision boundary used before shallow-result normalization.
+It deliberately performs no deletion, rewriting, or OMERO registration.  A
+caller can therefore run it in keep-only mode and safely retain every result
+when discovery or identity matching is incomplete.
+"""
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+from biomero_schema.zarr import (
+    CanonicalInput,
+    CanonicalInputManifest,
+    PixelIdentity,
+)
+
+from .pixel_identity import (
+    IsccBioIdentityProvider,
+    PixelIdentityError,
+    pixel_identities_match,
+    read_zarr_v2_semantic_guard,
+)
+
+
+@dataclass(frozen=True)
+class NgffNode:
+    """One explicitly discovered image or label node in a returned store."""
+
+    node_path: str
+    role: Literal["image", "label"]
+    parent_image_node_path: str | None = None
+
+
+@dataclass(frozen=True)
+class ReturnedZarrDecision:
+    """Keep-only result of comparing one returned store with workflow inputs."""
+
+    store_path: Path
+    outcome: Literal["eligible", "keep-full"]
+    reason: str
+    image_identities: tuple[PixelIdentity, ...] = ()
+    label_node_paths: tuple[str, ...] = ()
+    matched_inputs: tuple[CanonicalInput, ...] = ()
+
+    @property
+    def eligible(self) -> bool:
+        return self.outcome == "eligible"
+
+
+def _safe_node_path(value: str) -> str:
+    if not value or "\\" in value:
+        raise PixelIdentityError(f"Unsafe NGFF node path: {value!r}")
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts:
+        raise PixelIdentityError(f"Unsafe NGFF node path: {value!r}")
+    return value
+
+
+def _join_node_path(*parts: str) -> str:
+    useful = [part for part in parts if part and part != "."]
+    return str(PurePosixPath(*useful)) if useful else "."
+
+
+def _node_directory(root: Path, node_path: str) -> Path:
+    if node_path == ".":
+        return root
+    return root.joinpath(*PurePosixPath(node_path).parts)
+
+
+def _read_attrs(node: Path) -> dict:
+    path = node / ".zattrs"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PixelIdentityError(f"Cannot read NGFF attributes: {path}") from exc
+    if not isinstance(value, dict):
+        raise PixelIdentityError(f"Invalid NGFF attributes: {path}")
+    return value
+
+
+def _discover_labels(root: Path, image_node_path: str) -> list[NgffNode]:
+    image_node = _node_directory(root, image_node_path)
+    labels_group = image_node / "labels"
+    if not labels_group.is_dir():
+        return []
+    labels_attrs = _read_attrs(labels_group)
+    labels = labels_attrs.get("labels")
+    if not isinstance(labels, list):
+        raise PixelIdentityError(
+            f"NGFF labels metadata has no labels list: {labels_group}"
+        )
+
+    discovered = []
+    seen = set()
+    for label in labels:
+        if not isinstance(label, str):
+            raise PixelIdentityError("NGFF label names must be strings")
+        label = _safe_node_path(label)
+        label_node_path = _join_node_path(image_node_path, "labels", label)
+        if label_node_path in seen:
+            raise PixelIdentityError(
+                f"Duplicate NGFF label node: {label_node_path}"
+            )
+        label_attrs = _read_attrs(_node_directory(root, label_node_path))
+        if "multiscales" not in label_attrs:
+            raise PixelIdentityError(
+                f"NGFF label node has no multiscales metadata: {label_node_path}"
+            )
+        discovered.append(NgffNode(
+            node_path=label_node_path,
+            role="label",
+            parent_image_node_path=image_node_path,
+        ))
+        seen.add(label_node_path)
+    return discovered
+
+
+def discover_ngff_nodes(zarr_root: str | Path) -> tuple[NgffNode, ...]:
+    """Discover NGFF 0.4 image-level nodes by declared image/plate metadata."""
+    root = Path(zarr_root)
+    attrs = _read_attrs(root)
+    image_paths: list[str] = []
+
+    if "multiscales" in attrs:
+        image_paths.append(".")
+    elif "plate" in attrs:
+        plate = attrs["plate"]
+        wells = plate.get("wells") if isinstance(plate, dict) else None
+        if not isinstance(wells, list):
+            raise PixelIdentityError("NGFF plate metadata has no wells list")
+        for well in wells:
+            well_path = well.get("path") if isinstance(well, dict) else None
+            if not isinstance(well_path, str):
+                raise PixelIdentityError("NGFF plate well path is missing")
+            well_path = _safe_node_path(well_path)
+            well_attrs = _read_attrs(_node_directory(root, well_path))
+            well_metadata = well_attrs.get("well")
+            images = (
+                well_metadata.get("images")
+                if isinstance(well_metadata, dict)
+                else None
+            )
+            if not isinstance(images, list):
+                raise PixelIdentityError(
+                    f"NGFF well metadata has no images list: {well_path}"
+                )
+            for image in images:
+                image_path = image.get("path") if isinstance(image, dict) else None
+                if not isinstance(image_path, str):
+                    raise PixelIdentityError(
+                        f"NGFF well image path is missing: {well_path}"
+                    )
+                image_paths.append(_join_node_path(
+                    well_path,
+                    _safe_node_path(image_path),
+                ))
+    else:
+        raise PixelIdentityError(
+            "Returned Zarr root is neither an NGFF image nor an NGFF plate"
+        )
+
+    nodes: list[NgffNode] = []
+    seen_images = set()
+    for image_path in image_paths:
+        if image_path in seen_images:
+            raise PixelIdentityError(f"Duplicate NGFF image node: {image_path}")
+        image_attrs = _read_attrs(_node_directory(root, image_path))
+        if "multiscales" not in image_attrs:
+            raise PixelIdentityError(
+                f"NGFF image node has no multiscales metadata: {image_path}"
+            )
+        nodes.append(NgffNode(node_path=image_path, role="image"))
+        nodes.extend(_discover_labels(root, image_path))
+        seen_images.add(image_path)
+    return tuple(nodes)
+
+
+def find_returned_zarr_stores(results_path: str | Path) -> tuple[Path, ...]:
+    """Find outermost returned ``*.zarr`` stores and prune their internals."""
+    base = Path(results_path)
+    stores = []
+    for current, dirs, _files in os.walk(base):
+        zarr_dirs = sorted(name for name in dirs if name.lower().endswith(".zarr"))
+        stores.extend(Path(current) / name for name in zarr_dirs)
+        dirs[:] = [name for name in dirs if not name.lower().endswith(".zarr")]
+    return tuple(stores)
+
+
+def _identity_for_node(
+    root: Path,
+    node: NgffNode,
+    identity_provider: IsccBioIdentityProvider,
+) -> PixelIdentity:
+    guard = read_zarr_v2_semantic_guard(root, node.node_path)
+    return identity_provider.generate(
+        root,
+        node_path=node.node_path,
+        role=node.role,
+        shape=guard.shape,
+        dtype=guard.dtype,
+        axes=guard.axes,
+        coordinate_transformations=guard.coordinate_transformations,
+    )
+
+
+def evaluate_returned_zarr(
+    zarr_root: str | Path,
+    canonical_inputs: CanonicalInputManifest | None,
+    *,
+    identity_provider: IsccBioIdentityProvider | None = None,
+) -> ReturnedZarrDecision:
+    """Compare one returned image store with its workflow-scoped inputs.
+
+    The function only reports eligibility.  It never changes the returned
+    store, which makes failures and unsupported cases unconditionally fail
+    open to ``keep-full``.
+    """
+    root = Path(zarr_root)
+    if canonical_inputs is None or not canonical_inputs.inputs:
+        return ReturnedZarrDecision(
+            store_path=root,
+            outcome="keep-full",
+            reason="no-canonical-input-snapshot",
+        )
+
+    try:
+        nodes = discover_ngff_nodes(root)
+    except PixelIdentityError as exc:
+        return ReturnedZarrDecision(
+            store_path=root,
+            outcome="keep-full",
+            reason=f"unsupported-ngff: {exc}",
+        )
+
+    image_nodes = tuple(node for node in nodes if node.role == "image")
+    label_paths = tuple(node.node_path for node in nodes if node.role == "label")
+    if len(image_nodes) != 1:
+        return ReturnedZarrDecision(
+            store_path=root,
+            outcome="keep-full",
+            reason="unsupported-multi-image-result",
+            label_node_paths=label_paths,
+        )
+    if not label_paths:
+        return ReturnedZarrDecision(
+            store_path=root,
+            outcome="keep-full",
+            reason="no-label-nodes",
+        )
+
+    provider = identity_provider or IsccBioIdentityProvider()
+    try:
+        returned_identity = _identity_for_node(root, image_nodes[0], provider)
+    except PixelIdentityError as exc:
+        return ReturnedZarrDecision(
+            store_path=root,
+            outcome="keep-full",
+            reason=f"identity-unavailable: {exc}",
+            label_node_paths=label_paths,
+        )
+
+    artifact_matches = tuple(
+        item for item in canonical_inputs.inputs
+        if item.transfer_artifact == root.name
+    )
+    if len(artifact_matches) > 1:
+        reason = "ambiguous-transfer-artifact"
+        matches = ()
+    elif len(artifact_matches) == 1:
+        matches = artifact_matches
+        reason = (
+            "input-image-unchanged"
+            if pixel_identities_match(
+                returned_identity,
+                matches[0].source.pixel_identity,
+            )
+            else "pixels-changed"
+        )
+    else:
+        matches = tuple(
+            item for item in canonical_inputs.inputs
+            if pixel_identities_match(
+                returned_identity,
+                item.source.pixel_identity,
+            )
+        )
+        if len(matches) == 1:
+            reason = "input-image-unchanged"
+        elif len(matches) > 1:
+            reason = "ambiguous-input-identity"
+            matches = ()
+        else:
+            reason = "no-input-identity-match"
+
+    eligible = reason == "input-image-unchanged"
+    return ReturnedZarrDecision(
+        store_path=root,
+        outcome="eligible" if eligible else "keep-full",
+        reason=reason,
+        image_identities=(returned_identity,),
+        label_node_paths=label_paths,
+        matched_inputs=matches if eligible else (),
+    )
+
+
+__all__ = [
+    "NgffNode",
+    "ReturnedZarrDecision",
+    "discover_ngff_nodes",
+    "evaluate_returned_zarr",
+    "find_returned_zarr_stores",
+]

--- a/biomero_importer/utils/result_zarr.py
+++ b/biomero_importer/utils/result_zarr.py
@@ -21,6 +21,7 @@ from biomero_schema.zarr import (
     SHALLOW_COLLECTION_MANIFEST,
     ShallowCollection,
     ShallowImageReference,
+    ShallowZarrReference,
 )
 
 from .pixel_identity import (
@@ -45,7 +46,7 @@ class ReturnedZarrDecision:
     """Keep-only result of comparing one returned store with workflow inputs."""
 
     store_path: Path
-    outcome: Literal["eligible", "keep-full"]
+    outcome: Literal["eligible", "keep-full", "skip-passthrough"]
     reason: str
     image_identities: tuple[PixelIdentity, ...] = ()
     label_node_paths: tuple[str, ...] = ()
@@ -54,6 +55,10 @@ class ReturnedZarrDecision:
     @property
     def eligible(self) -> bool:
         return self.outcome == "eligible"
+
+    @property
+    def unchanged_passthrough(self) -> bool:
+        return self.outcome == "skip-passthrough"
 
 
 @dataclass(frozen=True)
@@ -64,6 +69,16 @@ class NormalizedShallowResult:
     collection: ShallowCollection
     bytes_before: int
     bytes_after: int
+
+
+@dataclass(frozen=True)
+class ShallowRegistration:
+    """Resolved registration view for a shallow result or label projection."""
+
+    collection_root: Path
+    registration_path: Path
+    reference: ShallowZarrReference
+    kind: Literal["primary", "label"]
 
 
 def _safe_node_path(value: str) -> str:
@@ -104,6 +119,188 @@ def _write_json(path: Path, value: dict) -> None:
         encoding="utf-8",
     )
     os.replace(temporary, path)
+
+
+def load_managed_storage_roots(
+    *,
+    import_mount_path: str | Path | None = None,
+    config_file: str | Path | None = None,
+    group_mappings_file: str | Path | None = None,
+) -> dict[str, Path]:
+    """Resolve managed roots from the shared runtime group mappings."""
+    import_root = Path(
+        import_mount_path or os.getenv("IMPORT_MOUNT_PATH", "/data")
+    ).resolve()
+    if not import_root.is_absolute():
+        raise ValueError("IMPORT_MOUNT_PATH must be absolute")
+
+    config_path = Path(config_file or os.getenv(
+        "OMERO_BIOMERO_CONFIG_FILE",
+        "/auto-importer/config/biomero-config.json",
+    ))
+    mappings_path = Path(group_mappings_file or os.getenv(
+        "OMERO_BIOMERO_GROUP_MAPPINGS_FILE",
+        "/auto-importer/config/group-mappings.json",
+    ))
+
+    def read_object(path: Path) -> dict:
+        if not path.is_file():
+            return {}
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"Cannot load managed storage mapping {path}") from exc
+        if not isinstance(value, dict):
+            raise ValueError(f"Managed storage mapping must be an object: {path}")
+        return value
+
+    legacy = read_object(config_path).get("group_mappings", {})
+    if not isinstance(legacy, dict):
+        raise ValueError("biomero-config.json group_mappings must be an object")
+    mappings = dict(legacy)
+    mappings.update(read_object(mappings_path))
+
+    roots = {"import-mount-data": import_root}
+    for group_id, mapping in mappings.items():
+        if not isinstance(mapping, dict):
+            raise ValueError(f"Invalid group mapping for {group_id!r}")
+        try:
+            normalized_id = int(group_id)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid group ID {group_id!r}") from exc
+        folder = mapping.get("folder")
+        if not folder or folder in {".", "root"}:
+            root = import_root
+        else:
+            folder_path = Path(str(folder))
+            if folder_path.is_absolute() or ".." in folder_path.parts:
+                raise ValueError(
+                    f"Group {normalized_id} folder must be relative to IMPORT_MOUNT_PATH"
+                )
+            root = (import_root / folder_path).resolve()
+            try:
+                root.relative_to(import_root)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Group {normalized_id} folder escapes IMPORT_MOUNT_PATH"
+                ) from exc
+        roots[f"group-{normalized_id}-data"] = root
+    return roots
+
+
+def resolve_managed_source_path(
+    source,
+    storage_roots: dict[str, Path],
+) -> Path:
+    """Resolve a canonical source without allowing its locator to escape."""
+    root = storage_roots.get(source.storage_root)
+    if root is None:
+        raise ValueError(f"Unknown managed storage root {source.storage_root!r}")
+    root = Path(root).resolve()
+    candidate = (root / Path(source.relative_path)).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(
+            f"Canonical source escapes storage root {source.storage_root}"
+        ) from exc
+    if not candidate.is_dir():
+        raise ValueError(f"Canonical source is unavailable: {candidate}")
+    return candidate
+
+
+def resolve_shallow_registration(
+    zarr_path: str | Path,
+    *,
+    storage_roots: dict[str, Path] | None = None,
+    import_mount_path: str | Path | None = None,
+) -> ShallowRegistration | None:
+    """Resolve a primary shallow result or one of its label projections."""
+    path = Path(zarr_path).resolve()
+    import_root = Path(
+        import_mount_path or os.getenv("IMPORT_MOUNT_PATH", "/data")
+    ).resolve()
+    try:
+        path.relative_to(import_root)
+    except ValueError:
+        return None
+
+    collection_root = None
+    for candidate in (path, *path.parents):
+        try:
+            candidate.relative_to(import_root)
+        except ValueError:
+            break
+        if (candidate / SHALLOW_COLLECTION_MANIFEST).is_file():
+            collection_root = candidate
+            break
+        if candidate == import_root:
+            break
+    if collection_root is None:
+        return None
+
+    try:
+        collection = ShallowCollection.from_dict(json.loads(
+            (collection_root / SHALLOW_COLLECTION_MANIFEST).read_text(
+                encoding="utf-8"
+            )
+        ))
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise PixelIdentityError(
+            f"Invalid shallow collection manifest: {collection_root}"
+        ) from exc
+
+    relative_node = (
+        "." if path == collection_root
+        else path.relative_to(collection_root).as_posix()
+    )
+    if relative_node == ".":
+        if len(collection.images) != 1:
+            raise PixelIdentityError(
+                "Primary registration currently requires one shallow image node"
+            )
+        image = collection.images[0]
+        kind = "primary"
+    else:
+        matches = [
+            image for image in collection.images
+            if relative_node in image.label_node_paths
+        ]
+        if len(matches) != 1:
+            raise PixelIdentityError(
+                f"Zarr path is not a declared shallow label: {path}"
+            )
+        image = matches[0]
+        kind = "label"
+
+    reference = ShallowZarrReference.from_collection(
+        collection,
+        storage_root="import-mount-data",
+        relative_path=collection_root.relative_to(import_root).as_posix(),
+        image_node_path=image.image_node_path,
+    )
+    if kind == "label":
+        registration_path = path
+    else:
+        roots = storage_roots or load_managed_storage_roots(
+            import_mount_path=import_root
+        )
+        registration_path = resolve_managed_source_path(image.source, roots)
+        if image.source.node_path != ".":
+            registration_path = _node_directory(
+                registration_path,
+                image.source.node_path,
+            )
+        if not registration_path.is_dir():
+            raise PixelIdentityError(
+                f"Shallow source image node is unavailable: {registration_path}"
+            )
+    return ShallowRegistration(
+        collection_root=collection_root,
+        registration_path=registration_path,
+        reference=reference,
+        kind=kind,
+    )
 
 
 def _discover_labels(root: Path, image_node_path: str) -> list[NgffNode]:
@@ -457,13 +654,6 @@ def evaluate_returned_zarr(
             reason="unsupported-multi-image-result",
             label_node_paths=label_paths,
         )
-    if not label_paths:
-        return ReturnedZarrDecision(
-            store_path=root,
-            outcome="keep-full",
-            reason="no-label-nodes",
-        )
-
     provider = identity_provider or IsccBioIdentityProvider()
     try:
         returned_identity = _identity_for_node(root, image_nodes[0], provider)
@@ -508,7 +698,16 @@ def evaluate_returned_zarr(
         else:
             reason = "no-input-identity-match"
 
-    eligible = reason == "input-image-unchanged"
+    unchanged = reason == "input-image-unchanged"
+    if unchanged and not label_paths:
+        return ReturnedZarrDecision(
+            store_path=root,
+            outcome="skip-passthrough",
+            reason="input-image-unchanged-no-labels",
+            image_identities=(returned_identity,),
+            matched_inputs=matches,
+        )
+    eligible = unchanged and bool(label_paths)
     return ReturnedZarrDecision(
         store_path=root,
         outcome="eligible" if eligible else "keep-full",
@@ -523,8 +722,12 @@ __all__ = [
     "NgffNode",
     "NormalizedShallowResult",
     "ReturnedZarrDecision",
+    "ShallowRegistration",
     "discover_ngff_nodes",
     "evaluate_returned_zarr",
     "find_returned_zarr_stores",
+    "load_managed_storage_roots",
     "normalize_returned_zarr",
+    "resolve_managed_source_path",
+    "resolve_shallow_registration",
 ]

--- a/biomero_importer/utils/result_zarr.py
+++ b/biomero_importer/utils/result_zarr.py
@@ -370,18 +370,17 @@ def materialize_shallow_zarr(
     provider = identity_provider or IsccBioIdentityProvider()
     components = image.label_components
     if not components:
-        discovered = {
-            node.node_path: node
-            for node in discover_ngff_nodes(collection_root)
-            if node.role == "label"
-        }
         legacy_components = []
         for logical_path in image.label_node_paths:
-            node = discovered.get(logical_path)
-            if node is None:
+            if not _node_directory(collection_root, logical_path).is_dir():
                 raise PixelIdentityError(
                     f"Legacy shallow collection lost label {logical_path}"
                 )
+            node = NgffNode(
+                node_path=logical_path,
+                role="label",
+                parent_image_node_path=image.image_node_path,
+            )
             identity = _identity_for_node(collection_root, node, provider)
             legacy_components.append(ZarrLabelComponent(
                 logical_node_path=logical_path,

--- a/biomero_importer/utils/result_zarr.py
+++ b/biomero_importer/utils/result_zarr.py
@@ -361,12 +361,12 @@ def materialize_shallow_zarr(
         raise PixelIdentityError(
             "Shallow reference no longer matches its collection manifest"
         )
-    if image.image_node_path != "." or image.source.node_path != ".":
-        raise PixelIdentityError(
-            "Materialization currently supports one root-level NGFF image"
-        )
-
     canonical_root = resolve_managed_source_path(image.source, storage_roots)
+    canonical_image = _node_directory(canonical_root, image.source.node_path)
+    if not canonical_image.is_dir():
+        raise PixelIdentityError(
+            f"Shallow source image node is unavailable: {canonical_image}"
+        )
     provider = identity_provider or IsccBioIdentityProvider()
     components = image.label_components
     if not components:
@@ -392,30 +392,32 @@ def materialize_shallow_zarr(
     staging = destination.with_name(
         f".{destination.name}.biomero-materialize-{token}"
     )
-    source_labels = canonical_root / "labels"
+    source_labels = canonical_image / "labels"
 
     def ignore(directory, names):
         current = Path(directory)
         ignored = {".biomero-canonical.json"}.intersection(names)
-        if current == canonical_root and source_labels.name in names:
+        if current == canonical_image and source_labels.name in names:
             ignored.add(source_labels.name)
         return ignored
 
     managed_labels = []
     try:
-        shutil.copytree(canonical_root, staging, symlinks=True, ignore=ignore)
+        shutil.copytree(canonical_image, staging, symlinks=True, ignore=ignore)
         labels_root = staging / "labels"
         labels_root.mkdir(parents=True, exist_ok=False)
         _write_json(labels_root / ".zgroup", {"zarr_format": 2})
         label_names = []
         for component in components:
-            prefix = PurePosixPath("labels")
+            prefix = PurePosixPath(
+                _join_node_path(image.image_node_path, "labels")
+            )
             logical = PurePosixPath(component.logical_node_path)
             try:
                 label_name = logical.relative_to(prefix).as_posix()
             except ValueError as exc:
                 raise PixelIdentityError(
-                    "Root-image label paths must be nested below labels/"
+                    "Label paths must be nested below their image labels/"
                 ) from exc
             label_names.append(label_name)
             if component.source is None:
@@ -438,17 +440,29 @@ def materialize_shallow_zarr(
                 raise PixelIdentityError(
                     f"Managed shallow label is unavailable: {physical_path}"
                 )
-            target = _node_directory(staging, component.logical_node_path)
+            target_node = _join_node_path("labels", label_name)
+            target = _node_directory(staging, target_node)
             shutil.copytree(physical_path, target, symlinks=True)
-            managed_labels.append(component.model_copy(update={
-                "source": managed_source,
-            }))
+            managed_labels.append(ZarrLabelComponent(
+                logical_node_path=target_node,
+                pixel_identity=component.pixel_identity.model_copy(update={
+                    "node_path": target_node,
+                }),
+                source=managed_source,
+            ))
         _write_json(labels_root / ".zattrs", {"labels": label_names})
         discovered_paths = {
             node.node_path for node in discover_ngff_nodes(staging)
             if node.role == "label"
         }
-        if discovered_paths != set(image.label_node_paths):
+        expected_paths = {
+            _join_node_path(
+                "labels",
+                PurePosixPath(path).relative_to(prefix).as_posix(),
+            )
+            for path in image.label_node_paths
+        }
+        if discovered_paths != expected_paths:
             raise PixelIdentityError(
                 "Materialized label inventory differs from shallow collection"
             )
@@ -657,49 +671,91 @@ def normalize_returned_zarr(
     """
     if not decision.eligible or len(decision.matched_inputs) != 1:
         raise PixelIdentityError("Returned Zarr is not eligible for shallowing")
-    if len(decision.image_identities) != 1:
-        raise PixelIdentityError("Expected exactly one returned image identity")
-
     root = decision.store_path
     if not root.is_dir():
         raise PixelIdentityError(f"Returned Zarr does not exist: {root}")
     nodes = discover_ngff_nodes(root)
     image_nodes = tuple(node for node in nodes if node.role == "image")
     label_nodes = tuple(node for node in nodes if node.role == "label")
-    if len(image_nodes) != 1 or not label_nodes:
+    if not image_nodes or not label_nodes:
         raise PixelIdentityError(
-            "Only one-image returned stores with declared labels can be "
-            "normalized in this implementation"
+            "Returned stores require image nodes and declared labels"
         )
-
-    image_node = image_nodes[0]
-    returned_identity = decision.image_identities[0]
-    if returned_identity.node_path != image_node.node_path:
+    returned_by_path = {
+        identity.node_path: identity
+        for identity in decision.image_identities
+    }
+    if set(returned_by_path) != {node.node_path for node in image_nodes}:
         raise PixelIdentityError(
-            "Returned identity no longer describes the discovered image node"
+            "Returned identities no longer describe the discovered image nodes"
         )
     matched_input = decision.matched_inputs[0]
-    if matched_input.transfer_artifact != root.name:
+    if (
+        matched_input.transfer_artifact is not None
+        and matched_input.transfer_artifact != root.name
+    ):
         raise PixelIdentityError(
             "Returned store name no longer matches its transferred artifact"
         )
 
+    if matched_input.plate_source is not None:
+        input_sources = {
+            image.image_node_path: image.source
+            for image in matched_input.plate_source.images
+        }
+        interchange_profile = matched_input.plate_source.interchange_profile
+    elif matched_input.source is not None:
+        input_sources = {matched_input.source.node_path: matched_input.source}
+        interchange_profile = matched_input.source.interchange_profile
+    else:
+        raise PixelIdentityError("Matched input has no canonical source")
+    if set(input_sources) != set(returned_by_path):
+        raise PixelIdentityError(
+            "Matched input no longer describes every returned image node"
+        )
+
+    components_by_image = {node.node_path: [] for node in image_nodes}
+    for component in decision.label_components:
+        matches = [
+            node.node_path for node in image_nodes
+            if PurePosixPath(component.logical_node_path).is_relative_to(
+                PurePosixPath(_join_node_path(node.node_path, "labels"))
+            )
+        ]
+        if len(matches) != 1:
+            raise PixelIdentityError(
+                f"Label has no unique parent image: {component.logical_node_path}"
+            )
+        components_by_image[matches[0]].append(component)
+
     collection = ShallowCollection(
         workflow_id=UUID(str(workflow_id)),
         transfer_artifact=root.name,
-        interchange_profile=matched_input.source.interchange_profile,
-        images=(ShallowImageReference(
-            image_node_path=image_node.node_path,
-            source=matched_input.source,
-            returned_pixel_identity=returned_identity,
-            label_node_paths=tuple(node.node_path for node in label_nodes),
-            label_components=decision.label_components,
-        ),),
+        interchange_profile=interchange_profile,
+        images=tuple(
+            ShallowImageReference(
+                image_node_path=image_node.node_path,
+                source=input_sources[image_node.node_path],
+                returned_pixel_identity=returned_by_path[image_node.node_path],
+                label_node_paths=tuple(
+                    component.logical_node_path
+                    for component in components_by_image[image_node.node_path]
+                ),
+                label_components=tuple(
+                    components_by_image[image_node.node_path]
+                ),
+            )
+            for image_node in image_nodes
+        ),
     )
-    omitted = set(_declared_image_dataset_directories(
-        root,
-        image_node.node_path,
-    ))
+    omitted = {
+        directory
+        for image_node in image_nodes
+        for directory in _declared_image_dataset_directories(
+            root,
+            image_node.node_path,
+        )
+    }
     inherited_label_paths = {
         component.logical_node_path
         for component in decision.label_components
@@ -725,18 +781,19 @@ def normalize_returned_zarr(
     committed = False
     try:
         shutil.copytree(root, staging, symlinks=True, ignore=ignore)
-        staging_attrs_path = _node_directory(
-            staging,
-            image_node.node_path,
-        ) / ".zattrs"
-        staging_attrs = _read_attrs(staging_attrs_path.parent)
-        staging_attrs.pop("multiscales", None)
-        staging_attrs["biomero"] = {
-            "model": collection.model,
-            "manifest": SHALLOW_COLLECTION_MANIFEST,
-            "workflowId": str(collection.workflow_id),
-        }
-        _write_json(staging_attrs_path, staging_attrs)
+        for image_node in image_nodes:
+            staging_attrs_path = _node_directory(
+                staging,
+                image_node.node_path,
+            ) / ".zattrs"
+            staging_attrs = _read_attrs(staging_attrs_path.parent)
+            staging_attrs.pop("multiscales", None)
+            staging_attrs["biomero"] = {
+                "model": collection.model,
+                "manifest": SHALLOW_COLLECTION_MANIFEST,
+                "workflowId": str(collection.workflow_id),
+            }
+            _write_json(staging_attrs_path, staging_attrs)
         _write_json(
             staging / SHALLOW_COLLECTION_MANIFEST,
             collection.to_dict(),
@@ -824,22 +881,54 @@ def evaluate_returned_zarr(
 
     image_nodes = tuple(node for node in nodes if node.role == "image")
     label_paths = tuple(node.node_path for node in nodes if node.role == "label")
-    if len(image_nodes) != 1:
+    if not image_nodes:
         return ReturnedZarrDecision(
             store_path=root,
             outcome="keep-full",
-            reason="unsupported-multi-image-result",
+            reason="no-image-nodes",
             label_node_paths=label_paths,
         )
     provider = identity_provider or IsccBioIdentityProvider()
     try:
-        returned_identity = _identity_for_node(root, image_nodes[0], provider)
+        returned_identities = tuple(
+            _identity_for_node(root, node, provider)
+            for node in image_nodes
+        )
     except PixelIdentityError as exc:
         return ReturnedZarrDecision(
             store_path=root,
             outcome="keep-full",
             reason=f"identity-unavailable: {exc}",
             label_node_paths=label_paths,
+        )
+
+    def sources_for(item: CanonicalInput):
+        if item.plate_source is not None:
+            return {
+                image.image_node_path: image.source
+                for image in item.plate_source.images
+            }
+        if item.source is not None:
+            return {item.source.node_path: item.source}
+        return {}
+
+    returned_by_path = {
+        identity.node_path: identity for identity in returned_identities
+    }
+    unchanged_reason = (
+        "input-image-unchanged"
+        if len(returned_identities) == 1
+        else "input-plate-unchanged"
+    )
+
+    def input_matches(item: CanonicalInput) -> bool:
+        sources = sources_for(item)
+        return set(sources) == set(returned_by_path) and all(
+            pixel_identities_match(
+                returned_by_path[node_path],
+                source.pixel_identity,
+            )
+            for node_path, source in sources.items()
         )
 
     artifact_matches = tuple(
@@ -852,36 +941,30 @@ def evaluate_returned_zarr(
     elif len(artifact_matches) == 1:
         matches = artifact_matches
         reason = (
-            "input-image-unchanged"
-            if pixel_identities_match(
-                returned_identity,
-                matches[0].source.pixel_identity,
-            )
+            unchanged_reason
+            if input_matches(matches[0])
             else "pixels-changed"
         )
     else:
         matches = tuple(
             item for item in canonical_inputs.inputs
-            if pixel_identities_match(
-                returned_identity,
-                item.source.pixel_identity,
-            )
+            if input_matches(item)
         )
         if len(matches) == 1:
-            reason = "input-image-unchanged"
+            reason = unchanged_reason
         elif len(matches) > 1:
             reason = "ambiguous-input-identity"
             matches = ()
         else:
             reason = "no-input-identity-match"
 
-    unchanged = reason == "input-image-unchanged"
+    unchanged = reason == unchanged_reason
     if unchanged and not label_paths:
         return ReturnedZarrDecision(
             store_path=root,
             outcome="skip-passthrough",
-            reason="input-image-unchanged-no-labels",
-            image_identities=(returned_identity,),
+            reason=f"{unchanged_reason}-no-labels",
+            image_identities=returned_identities,
             matched_inputs=matches,
         )
     if not unchanged or not label_paths:
@@ -889,7 +972,7 @@ def evaluate_returned_zarr(
             store_path=root,
             outcome="keep-full",
             reason=reason,
-            image_identities=(returned_identity,),
+            image_identities=returned_identities,
             label_node_paths=label_paths,
         )
 
@@ -904,14 +987,21 @@ def evaluate_returned_zarr(
             store_path=root,
             outcome="keep-full",
             reason=f"label-identity-unavailable: {exc}",
-            image_identities=(returned_identity,),
+            image_identities=returned_identities,
             label_node_paths=label_paths,
         )
 
-    input_labels = {
-        label.logical_node_path: label
-        for label in matches[0].labels
-    }
+    if matches[0].plate_source is not None:
+        input_labels = {
+            label.logical_node_path: label
+            for image in matches[0].plate_source.images
+            for label in image.labels
+        }
+    else:
+        input_labels = {
+            label.logical_node_path: label
+            for label in matches[0].labels
+        }
     label_components = []
     for identity in label_identities:
         inherited = input_labels.get(identity.node_path)
@@ -931,7 +1021,7 @@ def evaluate_returned_zarr(
         store_path=root,
         outcome="eligible",
         reason=reason,
-        image_identities=(returned_identity,),
+        image_identities=returned_identities,
         label_identities=label_identities,
         label_components=tuple(label_components),
         label_node_paths=label_paths,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ test = [
     "psycopg2-binary"
 ]
 identity = [
-    "iscc-bio @ git+https://github.com/bio-codes/iscc-bio.git@c536d7699b7d25592bfe5c91c947b749344b6914"
+    "iscc-bio[ome-zarr-plugin] @ git+https://github.com/bio-codes/iscc-bio.git@c536d7699b7d25592bfe5c91c947b749344b6914"
 ]
 
 [tool.setuptools.packages]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "psycopg2>=2.9.7",
     "zarr>=3",
     "alembic>=1.13",
-    "biomero-schema>=0.2,<0.3"
+    "biomero-schema>=0.2.dev0,<0.3"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "sqlalchemy>=2.0.28",
     "psycopg2>=2.9.7",
     "zarr>=3",
-    "alembic>=1.13"
+    "alembic>=1.13",
+    "biomero-schema>=0.2,<0.3"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ test = [
     "mock",
     "psycopg2-binary"
 ]
+identity = [
+    "iscc-bio @ git+https://github.com/bio-codes/iscc-bio.git@c536d7699b7d25592bfe5c91c947b749344b6914"
+]
 
 [tool.setuptools.packages]
 find = {}  # Scan the project directory with the default parameters

--- a/tests/benchmarks/benchmark_shallow_a1b1.py
+++ b/tests/benchmarks/benchmark_shallow_a1b1.py
@@ -28,7 +28,13 @@ from biomero_schema.zarr import (
     SHALLOW_COLLECTION_MANIFEST,
     ShallowCollection,
 )
+from biomero_schema.imports import (
+    ImportOptionsEnvelope,
+    ShallowZarrImportOperation,
+)
 
+from biomero_importer.utils import lifecycle as lifecycle_module
+from biomero_importer.utils.lifecycle import ImportLifecycleEngine
 from biomero_importer.utils import result_zarr as rz
 from biomero_importer.utils.pixel_identity import IsccBioIdentityProvider
 
@@ -368,6 +374,66 @@ def profile_move_normalize(
     }
 
 
+def profile_importer_lifecycle(root: Path, manifest_path: Path):
+    """Profile the production importer-owned evaluate/normalize hand-off."""
+
+    _, canonical, _ = build_contracts(root, manifest_path)
+    options = ImportOptionsEnvelope(operations=(
+        ShallowZarrImportOperation(canonicalInputs=canonical),
+    ))
+    timings = defaultdict(float)
+    original_evaluate = lifecycle_module.evaluate_returned_zarr
+    original_normalize = lifecycle_module.normalize_returned_zarr
+
+    def evaluate(*args, **kwargs):
+        return timed_call(
+            timings,
+            "identity_evaluation_seconds",
+            original_evaluate,
+            *args,
+            **kwargs,
+        )
+
+    def normalize(*args, **kwargs):
+        return timed_call(
+            timings,
+            "normalization_seconds",
+            original_normalize,
+            *args,
+            **kwargs,
+        )
+
+    bytes_before = rz._tree_size(root)
+    lifecycle_module.evaluate_returned_zarr = evaluate
+    lifecycle_module.normalize_returned_zarr = normalize
+    started = perf_counter()
+    try:
+        plan = ImportLifecycleEngine().prepare((root,), options)
+    finally:
+        lifecycle_module.evaluate_returned_zarr = original_evaluate
+        lifecycle_module.normalize_returned_zarr = original_normalize
+    total = perf_counter() - started
+    bytes_after = rz._tree_size(root)
+    roles = defaultdict(int)
+    for item in plan.items:
+        roles[item.role] += 1
+    return {
+        "total_seconds": total,
+        **timings,
+        "bytes_before": bytes_before,
+        "bytes_after": bytes_after,
+        "bytes_saved": bytes_before - bytes_after,
+        "saved_percent": (
+            100 * (bytes_before - bytes_after) / bytes_before
+            if bytes_before else 0
+        ),
+        "decision": plan.decisions[0].outcome if plan.decisions else None,
+        "prepared_items": len(plan.items),
+        "prepared_roles": dict(sorted(roles.items())),
+        "unaccounted_seconds": total - sum(timings.values()),
+    }
+
+
 def rounded(value):
     if isinstance(value, float):
         return round(value, 3)
@@ -381,10 +447,18 @@ def main():
     parser.add_argument("--move-root", type=Path)
     parser.add_argument("--move-fast-root", type=Path)
     parser.add_argument("--identity-only-root", type=Path)
+    parser.add_argument("--lifecycle-root", type=Path)
     parser.add_argument("--identity-workers", type=int, default=1)
     parser.add_argument("--manifest", type=Path, required=True)
     args = parser.parse_args()
-    if args.identity_only_root is not None:
+    if args.lifecycle_root is not None:
+        result = {
+            "importer_lifecycle": profile_importer_lifecycle(
+                args.lifecycle_root,
+                args.manifest,
+            ),
+        }
+    elif args.identity_only_root is not None:
         result = {
             "identity_verification": profile_identity(
                 args.identity_only_root,

--- a/tests/benchmarks/benchmark_shallow_a1b1.py
+++ b/tests/benchmarks/benchmark_shallow_a1b1.py
@@ -1,0 +1,389 @@
+"""Profile A1/B1 returned-Plate verification and normalization strategies.
+
+This is a manual benchmark, not part of the unit-test suite.  The full mode
+needs three identical disposable full-result copies: one for ISCC verification,
+one for the former retained-tree staging strategy, and one for the move-journal
+normalizer with diagnostic size scans.  ``--move-fast-root`` profiles the
+production move-journal path without those scans. A previously produced shallow
+manifest supplies the canonical input identities and label inventory.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+import json
+import os
+from pathlib import Path
+import shutil
+from time import perf_counter
+from uuid import UUID, uuid4
+
+from biomero_schema.zarr import (
+    CanonicalInput,
+    CanonicalInputManifest,
+    CanonicalPlateImage,
+    CanonicalPlateSource,
+    SHALLOW_COLLECTION_MANIFEST,
+    ShallowCollection,
+)
+
+from biomero_importer.utils import result_zarr as rz
+from biomero_importer.utils.pixel_identity import IsccBioIdentityProvider
+
+
+def timed_call(timings, name, function, *args, **kwargs):
+    started = perf_counter()
+    try:
+        return function(*args, **kwargs)
+    finally:
+        timings[name] += perf_counter() - started
+
+
+def build_contracts(root: Path, manifest_path: Path):
+    collection = ShallowCollection.from_dict(json.loads(
+        manifest_path.read_text(encoding="utf-8")
+    ))
+    first = collection.images[0].source
+    plate_images = tuple(
+        CanonicalPlateImage(
+            image_node_path=image.image_node_path,
+            source=image.source,
+            labels=tuple(
+                component for component in image.label_components
+                if component.source is not None
+            ),
+        )
+        for image in collection.images
+    )
+    plate_source = CanonicalPlateSource(
+        storage_root=first.storage_root,
+        relative_path=first.relative_path,
+        source_object_id=first.source_object_id,
+        source_generation=first.source_generation,
+        interchange_profile=first.interchange_profile,
+        images=plate_images,
+    )
+    matched = CanonicalInput(
+        ordinal=0,
+        selected_object_type="Plate",
+        selected_object_id=first.source_object_id,
+        transfer_artifact=root.name,
+        plate_source=plate_source,
+    )
+    canonical = CanonicalInputManifest(
+        workflow_id=collection.workflow_id,
+        export_task_id=UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+        inputs=(matched,),
+    )
+    components = tuple(
+        component
+        for image in collection.images
+        for component in image.label_components
+    )
+    decision = rz.ReturnedZarrDecision(
+        store_path=root,
+        outcome="eligible",
+        reason="input-plate-unchanged",
+        image_identities=tuple(
+            image.returned_pixel_identity for image in collection.images
+        ),
+        label_identities=tuple(
+            component.pixel_identity for component in components
+        ),
+        label_components=components,
+        label_node_paths=tuple(
+            component.logical_node_path for component in components
+        ),
+        matched_inputs=(matched,),
+    )
+    return collection, canonical, decision
+
+
+class TimedIdentityProvider:
+    def __init__(self):
+        self.delegate = IsccBioIdentityProvider()
+        self.timings = defaultdict(float)
+        self.calls = defaultdict(int)
+
+    def generate(self, root, **kwargs):
+        role = kwargs["role"]
+        self.calls[role] += 1
+        return timed_call(
+            self.timings,
+            f"hash_{role}_seconds",
+            self.delegate.generate,
+            root,
+            **kwargs,
+        )
+
+
+def profile_identity(root: Path, manifest_path: Path):
+    _, canonical, _ = build_contracts(root, manifest_path)
+    provider = TimedIdentityProvider()
+    timings = defaultdict(float)
+    original_discover = rz.discover_ngff_nodes
+
+    def discover(*args, **kwargs):
+        return timed_call(
+            timings,
+            "ngff_discovery_seconds",
+            original_discover,
+            *args,
+            **kwargs,
+        )
+
+    rz.discover_ngff_nodes = discover
+    started = perf_counter()
+    try:
+        decision = rz.evaluate_returned_zarr(
+            root,
+            canonical,
+            identity_provider=provider,
+        )
+    finally:
+        rz.discover_ngff_nodes = original_discover
+    total = perf_counter() - started
+    return {
+        "total_seconds": total,
+        **timings,
+        **provider.timings,
+        "image_hash_calls": provider.calls["image"],
+        "label_hash_calls": provider.calls["label"],
+        "decision": decision.outcome,
+        "unaccounted_seconds": total - sum(timings.values())
+        - sum(provider.timings.values()),
+    }
+
+
+def legacy_stage_normalize(root: Path, manifest_path: Path):
+    """Profile the former copy-retained-side implementation."""
+    collection, _, decision = build_contracts(root, manifest_path)
+    timings = defaultdict(float)
+    started = perf_counter()
+    nodes = timed_call(
+        timings, "ngff_discovery_seconds", rz.discover_ngff_nodes, root
+    )
+    image_nodes = tuple(node for node in nodes if node.role == "image")
+    omitted = set()
+    planning_started = perf_counter()
+    for image_node in image_nodes:
+        omitted.update(rz._declared_image_dataset_directories(
+            root,
+            image_node.node_path,
+        ))
+    inherited = {
+        component.logical_node_path
+        for component in decision.label_components
+        if component.source is not None
+    }
+    omitted.update(rz._node_directory(root, path) for path in inherited)
+    timings["normalization_planning_seconds"] += (
+        perf_counter() - planning_started
+    )
+    bytes_before = timed_call(
+        timings, "tree_size_before_seconds", rz._tree_size, root
+    )
+    token = uuid4().hex
+    staging = root.with_name(f".{root.name}.legacy-stage-{token}")
+    backup = root.with_name(f".{root.name}.legacy-full-{token}")
+
+    def ignore(directory, names):
+        current = Path(directory)
+        return {name for name in names if current / name in omitted}
+
+    timed_call(
+        timings,
+        "copy_retained_tree_seconds",
+        shutil.copytree,
+        root,
+        staging,
+        symlinks=True,
+        ignore=ignore,
+    )
+    metadata_started = perf_counter()
+    for image_node in image_nodes:
+        attrs_path = rz._node_directory(staging, image_node.node_path) / ".zattrs"
+        attrs = rz._read_attrs(attrs_path.parent)
+        attrs.pop("multiscales", None)
+        attrs["biomero"] = {
+            "model": collection.model,
+            "manifest": SHALLOW_COLLECTION_MANIFEST,
+            "workflowId": str(collection.workflow_id),
+        }
+        rz._write_json(attrs_path, attrs)
+    rz._write_json(
+        staging / SHALLOW_COLLECTION_MANIFEST,
+        collection.to_dict(),
+    )
+    ShallowCollection.from_dict(json.loads(
+        (staging / SHALLOW_COLLECTION_MANIFEST).read_text(encoding="utf-8")
+    ))
+    timings["metadata_manifest_seconds"] += perf_counter() - metadata_started
+    swap_started = perf_counter()
+    os.replace(root, backup)
+    os.replace(staging, root)
+    timings["atomic_swap_seconds"] += perf_counter() - swap_started
+    bytes_after = timed_call(
+        timings, "tree_size_after_seconds", rz._tree_size, root
+    )
+    timed_call(
+        timings, "delete_full_backup_seconds", shutil.rmtree, backup
+    )
+    total = perf_counter() - started
+    return {
+        "total_seconds": total,
+        **timings,
+        "bytes_before": bytes_before,
+        "bytes_after": bytes_after,
+        "unaccounted_seconds": total - sum(timings.values()),
+    }
+
+
+def profile_move_normalize(
+    root: Path,
+    manifest_path: Path,
+    *,
+    measure_bytes: bool = True,
+):
+    collection, _, decision = build_contracts(root, manifest_path)
+    timings = defaultdict(float)
+    counts = defaultdict(int)
+    originals = {
+        "discover": rz.discover_ngff_nodes,
+        "datasets": rz._declared_image_dataset_directories,
+        "tree_size": rz._tree_size,
+        "read_attrs": rz._read_attrs,
+        "write_json": rz._write_json,
+        "rmtree": rz.shutil.rmtree,
+    }
+
+    def discover(*args, **kwargs):
+        return timed_call(
+            timings, "ngff_discovery_seconds", originals["discover"],
+            *args, **kwargs
+        )
+
+    def datasets(*args, **kwargs):
+        return timed_call(
+            timings, "dataset_planning_seconds", originals["datasets"],
+            *args, **kwargs
+        )
+
+    def tree_size(*args, **kwargs):
+        index = counts["tree_size"]
+        counts["tree_size"] += 1
+        name = (
+            "tree_size_before_seconds" if index == 0
+            else "tree_size_after_seconds"
+        )
+        return timed_call(
+            timings, name, originals["tree_size"], *args, **kwargs
+        )
+
+    def read_attrs(*args, **kwargs):
+        counts["attrs_reads"] += 1
+        return timed_call(
+            timings, "attrs_read_seconds", originals["read_attrs"],
+            *args, **kwargs
+        )
+
+    def write_json(*args, **kwargs):
+        counts["json_writes"] += 1
+        return timed_call(
+            timings, "metadata_manifest_write_seconds",
+            originals["write_json"], *args, **kwargs
+        )
+
+    def rmtree(*args, **kwargs):
+        counts["rmtree_calls"] += 1
+        return timed_call(
+            timings, "delete_pruned_arrays_seconds", originals["rmtree"],
+            *args, **kwargs
+        )
+
+    def replace(source, target):
+        counts["array_moves"] += 1
+        return timed_call(
+            timings, "move_arrays_seconds", os.replace, source, target
+        )
+
+    rz.discover_ngff_nodes = discover
+    rz._declared_image_dataset_directories = datasets
+    rz._tree_size = tree_size
+    rz._read_attrs = read_attrs
+    rz._write_json = write_json
+    rz.shutil.rmtree = rmtree
+    started = perf_counter()
+    try:
+        result = rz.normalize_returned_zarr(
+            decision,
+            collection.workflow_id,
+            replace=replace,
+            measure_bytes=measure_bytes,
+        )
+    finally:
+        rz.discover_ngff_nodes = originals["discover"]
+        rz._declared_image_dataset_directories = originals["datasets"]
+        rz._tree_size = originals["tree_size"]
+        rz._read_attrs = originals["read_attrs"]
+        rz._write_json = originals["write_json"]
+        rz.shutil.rmtree = originals["rmtree"]
+    total = perf_counter() - started
+    return {
+        "total_seconds": total,
+        **timings,
+        **counts,
+        "bytes_before": result.bytes_before,
+        "bytes_after": result.bytes_after,
+        "unaccounted_seconds": total - sum(timings.values()),
+    }
+
+
+def rounded(value):
+    if isinstance(value, float):
+        return round(value, 3)
+    return value
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--identity-root", type=Path)
+    parser.add_argument("--legacy-root", type=Path)
+    parser.add_argument("--move-root", type=Path)
+    parser.add_argument("--move-fast-root", type=Path)
+    parser.add_argument("--manifest", type=Path, required=True)
+    args = parser.parse_args()
+    if args.move_fast_root is not None:
+        result = {
+            "move_journal_without_size_scans": profile_move_normalize(
+                args.move_fast_root,
+                args.manifest,
+                measure_bytes=False,
+            ),
+        }
+    else:
+        if not all((args.identity_root, args.legacy_root, args.move_root)):
+            parser.error(
+                "identity, legacy, and move roots are required for the full "
+                "benchmark"
+            )
+        result = {
+            "identity_verification": profile_identity(
+                args.identity_root, args.manifest
+            ),
+            "legacy_copy_staging": legacy_stage_normalize(
+                args.legacy_root, args.manifest
+            ),
+            "move_journal": profile_move_normalize(
+                args.move_root, args.manifest
+            ),
+        }
+    print(json.dumps({
+        group: {key: rounded(value) for key, value in values.items()}
+        for group, values in result.items()
+    }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/benchmark_shallow_a1b1.py
+++ b/tests/benchmarks/benchmark_shallow_a1b1.py
@@ -16,6 +16,7 @@ import json
 import os
 from pathlib import Path
 import shutil
+from threading import Lock
 from time import perf_counter
 from uuid import UUID, uuid4
 
@@ -105,24 +106,31 @@ class TimedIdentityProvider:
         self.delegate = IsccBioIdentityProvider()
         self.timings = defaultdict(float)
         self.calls = defaultdict(int)
+        self.lock = Lock()
 
     def generate(self, root, **kwargs):
         role = kwargs["role"]
-        self.calls[role] += 1
-        return timed_call(
-            self.timings,
-            f"hash_{role}_seconds",
-            self.delegate.generate,
-            root,
-            **kwargs,
-        )
+        started = perf_counter()
+        try:
+            return self.delegate.generate(root, **kwargs)
+        finally:
+            elapsed = perf_counter() - started
+            with self.lock:
+                self.calls[role] += 1
+                self.timings[f"hash_{role}_seconds"] += elapsed
 
 
-def profile_identity(root: Path, manifest_path: Path):
+def profile_identity(
+    root: Path,
+    manifest_path: Path,
+    *,
+    identity_workers: int = 1,
+):
     _, canonical, _ = build_contracts(root, manifest_path)
     provider = TimedIdentityProvider()
     timings = defaultdict(float)
     original_discover = rz.discover_ngff_nodes
+    original_identity_batch = rz._identities_for_nodes
 
     def discover(*args, **kwargs):
         return timed_call(
@@ -133,26 +141,46 @@ def profile_identity(root: Path, manifest_path: Path):
             **kwargs,
         )
 
+    def identity_batch(root, nodes, identity_provider, **kwargs):
+        role = nodes[0].role if nodes else "empty"
+        return timed_call(
+            timings,
+            f"hash_{role}_phase_seconds",
+            original_identity_batch,
+            root,
+            nodes,
+            identity_provider,
+            **kwargs,
+        )
+
     rz.discover_ngff_nodes = discover
+    rz._identities_for_nodes = identity_batch
     started = perf_counter()
     try:
         decision = rz.evaluate_returned_zarr(
             root,
             canonical,
             identity_provider=provider,
+            identity_workers=identity_workers,
         )
     finally:
         rz.discover_ngff_nodes = original_discover
+        rz._identities_for_nodes = original_identity_batch
     total = perf_counter() - started
     return {
         "total_seconds": total,
         **timings,
-        **provider.timings,
+        "aggregate_image_worker_seconds": provider.timings[
+            "hash_image_seconds"
+        ],
+        "aggregate_label_worker_seconds": provider.timings[
+            "hash_label_seconds"
+        ],
         "image_hash_calls": provider.calls["image"],
         "label_hash_calls": provider.calls["label"],
+        "identity_workers": identity_workers,
         "decision": decision.outcome,
-        "unaccounted_seconds": total - sum(timings.values())
-        - sum(provider.timings.values()),
+        "unaccounted_seconds": total - sum(timings.values()),
     }
 
 
@@ -352,9 +380,19 @@ def main():
     parser.add_argument("--legacy-root", type=Path)
     parser.add_argument("--move-root", type=Path)
     parser.add_argument("--move-fast-root", type=Path)
+    parser.add_argument("--identity-only-root", type=Path)
+    parser.add_argument("--identity-workers", type=int, default=1)
     parser.add_argument("--manifest", type=Path, required=True)
     args = parser.parse_args()
-    if args.move_fast_root is not None:
+    if args.identity_only_root is not None:
+        result = {
+            "identity_verification": profile_identity(
+                args.identity_only_root,
+                args.manifest,
+                identity_workers=args.identity_workers,
+            ),
+        }
+    elif args.move_fast_root is not None:
         result = {
             "move_journal_without_size_scans": profile_move_normalize(
                 args.move_fast_root,
@@ -370,7 +408,9 @@ def main():
             )
         result = {
             "identity_verification": profile_identity(
-                args.identity_root, args.manifest
+                args.identity_root,
+                args.manifest,
+                identity_workers=args.identity_workers,
             ),
             "legacy_copy_staging": legacy_stage_normalize(
                 args.legacy_root, args.manifest

--- a/tests/unittests/test_api.py
+++ b/tests/unittests/test_api.py
@@ -1,0 +1,92 @@
+from uuid import uuid4
+
+import pytest
+
+from biomero_schema.imports import (
+    ImportOptionsEnvelope,
+    ShallowZarrImportOperation,
+)
+from biomero_schema.zarr import CanonicalInputManifest
+
+from biomero_importer.api import (
+    UnsupportedImportOperation,
+    get_importer_capabilities,
+    submit_import_order,
+)
+
+
+def _order(options=None):
+    order = {
+        "Group": "test",
+        "Username": "user",
+        "UUID": str(uuid4()),
+        "DestinationID": 1,
+        "DestinationType": "Dataset",
+        "Files": ["/data/result.zarr"],
+    }
+    if options is not None:
+        order["ImportOptions"] = options
+    return order
+
+
+def _operation():
+    return ShallowZarrImportOperation(
+        canonicalInputs=CanonicalInputManifest(
+            workflowId=uuid4(),
+            exportTaskId=uuid4(),
+            inputs=(),
+        )
+    )
+
+
+def test_capability_is_opt_in(monkeypatch):
+    monkeypatch.delenv("BIOMERO_SHALLOW_ZARR", raising=False)
+    assert get_importer_capabilities()["lifecycleOperations"] == []
+
+    monkeypatch.setenv("BIOMERO_SHALLOW_ZARR", "true")
+    assert get_importer_capabilities()["lifecycleOperations"] == [
+        "biomero.shallow-zarr"
+    ]
+
+
+def test_legacy_order_is_submitted_unchanged(monkeypatch):
+    monkeypatch.delenv("BIOMERO_SHALLOW_ZARR", raising=False)
+    events = []
+    order = _order({"schema": 1})
+
+    returned = submit_import_order(
+        order,
+        log_order=lambda value, stage: events.append((value, stage)),
+    )
+
+    assert returned == order["UUID"]
+    assert events[0][0]["ImportOptions"] == {"schema": 1}
+    assert events[0][1] == "Import Pending"
+
+
+def test_operation_order_requires_capability(monkeypatch):
+    monkeypatch.delenv("BIOMERO_SHALLOW_ZARR", raising=False)
+    order = _order(ImportOptionsEnvelope(
+        operations=(_operation(),)
+    ).to_dict())
+
+    with pytest.raises(UnsupportedImportOperation):
+        submit_import_order(order, log_order=lambda *_: None)
+
+
+def test_operation_order_is_normalized_and_submitted(monkeypatch):
+    monkeypatch.setenv("BIOMERO_SHALLOW_ZARR", "true")
+    events = []
+    order = _order(ImportOptionsEnvelope(
+        operations=(_operation(),)
+    ).to_dict())
+
+    submit_import_order(
+        order,
+        log_order=lambda value, stage: events.append((value, stage)),
+    )
+
+    assert events[0][0]["ImportOptions"]["schema"] == 2
+    assert events[0][0]["ImportOptions"]["operations"][0]["kind"] == (
+        "biomero.shallow-zarr"
+    )

--- a/tests/unittests/test_canonical_promotion.py
+++ b/tests/unittests/test_canonical_promotion.py
@@ -169,3 +169,48 @@ def test_adopts_matching_commit_after_annotation_gap(tmp_path):
     assert adopted.path == first.path
     assert adopted.source == first.source
     assert retry_staging.is_dir()
+
+
+def test_indexes_existing_managed_zarr_without_moving_or_copying(tmp_path):
+    managed_root = tmp_path / "managed"
+    existing = managed_root / "workflow/results/image.zarr"
+    make_zarr(existing)
+
+    indexed = service(tmp_path).index_existing(
+        existing,
+        relative_path="workflow/results/image.zarr",
+        source_object_type="Image",
+        source_object_id=3207,
+        source_generation=1,
+        node_path=".",
+        original_identity=identity(),
+        existing_identity=identity(),
+        pixel_identity_origin="omero-pixels",
+    )
+
+    assert indexed.path == existing.resolve()
+    assert indexed.source.relative_path == "workflow/results/image.zarr"
+    assert indexed.source.pixel_identity == identity()
+    assert existing.is_dir()
+    assert not (existing / canonical_store.CANONICAL_MARKER_NAME).exists()
+
+
+def test_existing_index_rejects_pixel_mismatch(tmp_path):
+    managed_root = tmp_path / "managed"
+    existing = managed_root / "workflow/results/image.zarr"
+    make_zarr(existing)
+
+    with pytest.raises(CanonicalPixelMismatch, match="Existing pixels"):
+        service(tmp_path).index_existing(
+            existing,
+            relative_path="workflow/results/image.zarr",
+            source_object_type="Image",
+            source_object_id=3207,
+            source_generation=1,
+            node_path=".",
+            original_identity=identity(),
+            existing_identity=identity(instance="ISCC:IDIFFERENT"),
+            pixel_identity_origin="omero-pixels",
+        )
+
+    assert existing.is_dir()

--- a/tests/unittests/test_canonical_promotion.py
+++ b/tests/unittests/test_canonical_promotion.py
@@ -1,0 +1,171 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+from biomero_schema.zarr import PixelIdentity
+
+
+def load_module(name, relative_path):
+    path = Path(__file__).parents[2] / relative_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+canonical_store = load_module(
+    "canonical_store", "biomero_importer/utils/canonical_store.py"
+)
+pixel_identity = load_module(
+    "pixel_identity", "biomero_importer/utils/pixel_identity.py"
+)
+canonical_promotion = load_module(
+    "canonical_promotion", "biomero_importer/utils/canonical_promotion.py"
+)
+
+CanonicalPromotionService = canonical_promotion.CanonicalPromotionService
+CanonicalPixelMismatch = canonical_promotion.CanonicalPixelMismatch
+
+
+def identity(instance="ISCC:IINSTANCE", shape=(1, 1, 8, 8), node_path="."):
+    return PixelIdentity(
+        node_path=node_path,
+        role="image",
+        iscc_code="ISCC:KSUM",
+        data_code="ISCC:GDATA",
+        instance_code=instance,
+        tool_version="0.1.0",
+        imagewalk_revision="iscc-bio/0.1.0@revision",
+        shape=shape,
+        dtype="uint16",
+        axes=("t", "c", "y", "x"),
+        coordinate_transformations=(
+            {"type": "scale", "scale": [1, 1, 0.5, 0.5]},
+        ),
+    )
+
+
+def make_zarr(path):
+    path.mkdir(parents=True)
+    (path / ".zgroup").write_text('{"zarr_format": 2}', encoding="utf-8")
+
+
+def service(tmp_path):
+    return CanonicalPromotionService(
+        storage_root_id="group-3-data",
+        storage_root=tmp_path / "managed",
+        canonical_store_factory=canonical_store.CanonicalStore,
+        identities_match=pixel_identity.pixel_identities_match,
+    )
+
+
+def test_verifies_and_atomically_promotes_first_export(tmp_path):
+    staging = tmp_path / "workflow" / "result.zarr"
+    make_zarr(staging)
+    promotion = service(tmp_path)
+
+    result = promotion.promote(
+        staging,
+        source_directory="project/dataset",
+        source_object_type="Image",
+        source_object_id=3207,
+        source_generation=1,
+        node_path=".",
+        original_identity=identity(),
+        exported_identity=identity(),
+        pixel_identity_origin="omero-pixels",
+    )
+
+    expected = (
+        tmp_path
+        / "managed/project/dataset/.processed/Image-3207.g1.ome.zarr"
+    )
+    assert result.path == expected
+    assert not staging.exists()
+    assert result.source.storage_root == "group-3-data"
+    assert result.source.relative_path == (
+        "project/dataset/.processed/Image-3207.g1.ome.zarr"
+    )
+    assert result.source.pixel_identity == identity()
+    assert result.source.canonical_pixel_verified is True
+    marker = json.loads(
+        (expected / canonical_store.CANONICAL_MARKER_NAME).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert marker["source"] == result.source.to_dict()
+
+
+def test_mismatch_never_promotes_or_removes_staging(tmp_path):
+    staging = tmp_path / "workflow" / "result.zarr"
+    make_zarr(staging)
+
+    with pytest.raises(CanonicalPixelMismatch, match="Image 3207"):
+        service(tmp_path).promote(
+            staging,
+            source_directory="project",
+            source_object_type="Image",
+            source_object_id=3207,
+            source_generation=1,
+            node_path=".",
+            original_identity=identity(),
+            exported_identity=identity(instance="ISCC:IDIFFERENT"),
+            pixel_identity_origin="omero-pixels",
+        )
+
+    assert staging.is_dir()
+    assert not (tmp_path / "managed/project/.processed").exists()
+
+
+def test_rejects_identity_for_a_different_node(tmp_path):
+    staging = tmp_path / "workflow" / "result.zarr"
+    make_zarr(staging)
+
+    with pytest.raises(CanonicalPixelMismatch, match="node path"):
+        service(tmp_path).promote(
+            staging,
+            source_directory="project",
+            source_object_type="Image",
+            source_object_id=3207,
+            source_generation=1,
+            node_path="0",
+            original_identity=identity(node_path="."),
+            exported_identity=identity(node_path="."),
+            pixel_identity_origin="omero-pixels",
+        )
+
+
+def test_adopts_matching_commit_after_annotation_gap(tmp_path):
+    first_staging = tmp_path / "workflow-1" / "result.zarr"
+    make_zarr(first_staging)
+    promotion = service(tmp_path)
+    first = promotion.promote(
+        first_staging,
+        source_directory="project",
+        source_object_type="Image",
+        source_object_id=3207,
+        source_generation=1,
+        node_path=".",
+        original_identity=identity(),
+        exported_identity=identity(),
+        pixel_identity_origin="omero-pixels",
+    )
+    retry_staging = tmp_path / "workflow-2" / "result.zarr"
+    make_zarr(retry_staging)
+
+    adopted = promotion.promote(
+        retry_staging,
+        source_directory="project",
+        source_object_type="Image",
+        source_object_id=3207,
+        source_generation=1,
+        node_path=".",
+        original_identity=identity(),
+        exported_identity=identity(),
+        pixel_identity_origin="omero-pixels",
+    )
+
+    assert adopted.path == first.path
+    assert adopted.source == first.source
+    assert retry_staging.is_dir()

--- a/tests/unittests/test_canonical_store.py
+++ b/tests/unittests/test_canonical_store.py
@@ -4,7 +4,12 @@ import importlib.util
 from pathlib import Path
 
 import pytest
-from biomero_schema.zarr import CanonicalZarrSource
+from biomero_schema.zarr import (
+    CanonicalPlateImage,
+    CanonicalPlateSource,
+    CanonicalZarrSource,
+    PixelIdentity,
+)
 
 MODULE_PATH = (
     Path(__file__).parents[2]
@@ -77,6 +82,50 @@ def test_accepts_shared_pydantic_source_contract(tmp_path, source_record):
 
     assert destination == (
         tmp_path / "project/.processed/Image-3207.g1.ome.zarr"
+    )
+
+
+def test_accepts_shared_plate_source_contract(tmp_path):
+    identity = PixelIdentity(
+        node_path="A/1/0",
+        role="image",
+        iscc="ISCC:KPIXEL",
+        dataCode="ISCC:GDATA",
+        instanceCode="ISCC:IINSTANCE",
+        toolVersion="0.1.0",
+        imagewalkRevision="draft-2026-06",
+        shape=(1, 1, 16, 16),
+        dtype="uint16",
+        axes=("t", "c", "y", "x"),
+    )
+    image_source = CanonicalZarrSource(
+        storageRoot="group-5-data",
+        relativePath="project/.processed/Plate-9.g1.ome.zarr",
+        nodePath="A/1/0",
+        sourceObjectType="Plate",
+        sourceObjectId=9,
+        sourceGeneration=1,
+        interchangeProfile="ngff-0.4-zarr-v2",
+        pixelIdentity=identity,
+        pixelIdentityOrigin="canonical-bootstrap",
+        canonicalPixelVerified=False,
+    )
+    plate = CanonicalPlateSource(
+        storageRoot="group-5-data",
+        relativePath="project/.processed/Plate-9.g1.ome.zarr",
+        sourceObjectId=9,
+        sourceGeneration=1,
+        interchangeProfile="ngff-0.4-zarr-v2",
+        images=(CanonicalPlateImage(
+            imageNodePath="A/1/0",
+            source=image_source,
+        ),),
+    )
+
+    destination = CanonicalStore(tmp_path).destination_for(plate)
+
+    assert destination == (
+        tmp_path / "project/.processed/Plate-9.g1.ome.zarr"
     )
 
 

--- a/tests/unittests/test_canonical_store.py
+++ b/tests/unittests/test_canonical_store.py
@@ -25,6 +25,9 @@ CANONICAL_MARKER_NAME = canonical_store.CANONICAL_MARKER_NAME
 CanonicalCreationLocked = canonical_store.CanonicalCreationLocked
 CanonicalStore = canonical_store.CanonicalStore
 InvalidCanonicalStore = canonical_store.InvalidCanonicalStore
+external_canonical_marker_path = canonical_store.external_canonical_marker_path
+load_canonical_marker = canonical_store.load_canonical_marker
+write_indexed_canonical_marker = canonical_store.write_indexed_canonical_marker
 
 
 @pytest.fixture
@@ -153,6 +156,51 @@ def test_atomically_promotes_zarr_with_committed_marker(
     )
     assert marker["state"] == "committed"
     assert marker["source"] == source_record
+
+
+def test_indexes_native_zarr_with_external_marker(tmp_path, source_record):
+    native = tmp_path / "incoming.ome.zarr"
+    make_zarr_v2(native)
+
+    marker_path = write_indexed_canonical_marker(native, source_record)
+
+    assert marker_path == (
+        tmp_path / ".biomero/incoming.ome.zarr.canonical.json"
+    )
+    assert not (native / CANONICAL_MARKER_NAME).exists()
+    assert load_canonical_marker(native) == CanonicalZarrSource.from_dict(
+        source_record
+    )
+
+
+def test_external_marker_round_trips_plate_identity_inventory(
+    tmp_path, source_record
+):
+    native = tmp_path / "plate.ome.zarr"
+    make_zarr_v2(native)
+    plate_image_source = CanonicalZarrSource.from_dict({
+        **source_record,
+        "relativePath": "plate.ome.zarr",
+        "nodePath": "A/1/0",
+        "sourceObjectType": "Plate",
+        "sourceObjectId": 9,
+        "canonicalPixelVerified": False,
+    })
+    plate = CanonicalPlateSource(
+        storageRoot="group-5-data",
+        relativePath="plate.ome.zarr",
+        sourceObjectId=9,
+        sourceGeneration=1,
+        interchangeProfile="ngff-0.4-zarr-v2",
+        images=(CanonicalPlateImage(
+            imageNodePath="A/1/0",
+            source=plate_image_source,
+        ),),
+    )
+
+    write_indexed_canonical_marker(native, plate)
+
+    assert load_canonical_marker(native) == plate
 
 
 def test_promotes_across_filesystems_via_destination_staging(

--- a/tests/unittests/test_canonical_store.py
+++ b/tests/unittests/test_canonical_store.py
@@ -1,0 +1,168 @@
+import json
+import importlib.util
+from pathlib import Path
+
+import pytest
+from biomero_schema.zarr import CanonicalZarrSource
+
+MODULE_PATH = (
+    Path(__file__).parents[2]
+    / "biomero_importer"
+    / "utils"
+    / "canonical_store.py"
+)
+SPEC = importlib.util.spec_from_file_location("canonical_store", MODULE_PATH)
+canonical_store = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(canonical_store)
+
+CANONICAL_MARKER_NAME = canonical_store.CANONICAL_MARKER_NAME
+CanonicalCreationLocked = canonical_store.CanonicalCreationLocked
+CanonicalStore = canonical_store.CanonicalStore
+InvalidCanonicalStore = canonical_store.InvalidCanonicalStore
+
+
+@pytest.fixture
+def source_record():
+    return {
+        "schema": 1,
+        "storageRoot": "group-5-data",
+        "relativePath": "project/.processed/Image-3207.g1.ome.zarr",
+        "nodePath": ".",
+        "sourceObjectType": "Image",
+        "sourceObjectId": 3207,
+        "sourceGeneration": 1,
+        "interchangeProfile": "ngff-0.4-zarr-v2",
+        "pixelIdentity": {
+            "schema": 1,
+            "method": "iscc-bio/imagewalk",
+            "nodePath": ".",
+            "role": "image",
+            "iscc": "ISCC:KPIXEL",
+            "dataCode": "ISCC:GDATA",
+            "instanceCode": "ISCC:IINSTANCE",
+            "toolVersion": "0.1.0",
+            "imagewalkRevision": "draft-2026-06",
+            "shape": [1, 1, 1, 16, 16],
+            "dtype": "uint16",
+            "axes": ["t", "c", "z", "y", "x"],
+            "coordinateTransformations": [],
+        },
+        "pixelIdentityOrigin": "raw",
+        "canonicalPixelVerified": True,
+        "storeIdentity": None,
+    }
+
+
+def make_zarr_v2(path: Path):
+    path.mkdir(parents=True)
+    (path / ".zgroup").write_text('{"zarr_format": 2}', encoding="utf-8")
+
+
+def test_builds_deterministic_processed_path(tmp_path):
+    store = CanonicalStore(tmp_path)
+
+    relative = store.relative_path_for("project", "Image", 3207, 1)
+
+    assert relative == Path("project/.processed/Image-3207.g1.ome.zarr")
+    assert store.resolve(relative) == (
+        tmp_path / "project/.processed/Image-3207.g1.ome.zarr"
+    )
+
+
+def test_accepts_shared_pydantic_source_contract(tmp_path, source_record):
+    source = CanonicalZarrSource.from_dict(source_record)
+
+    destination = CanonicalStore(tmp_path).destination_for(source)
+
+    assert destination == (
+        tmp_path / "project/.processed/Image-3207.g1.ome.zarr"
+    )
+
+
+def test_rejects_relative_path_escape(tmp_path):
+    store = CanonicalStore(tmp_path)
+
+    with pytest.raises(ValueError, match="managed storage root"):
+        store.resolve("../outside.ome.zarr")
+
+
+def test_atomically_promotes_zarr_with_committed_marker(
+    tmp_path, source_record
+):
+    store = CanonicalStore(tmp_path)
+    staging = tmp_path / "staging.ome.zarr"
+    make_zarr_v2(staging)
+
+    committed = store.commit(staging, source_record)
+
+    assert committed == tmp_path / source_record["relativePath"]
+    assert committed.is_dir()
+    assert not staging.exists()
+    marker = json.loads(
+        (committed / CANONICAL_MARKER_NAME).read_text(encoding="utf-8")
+    )
+    assert marker["state"] == "committed"
+    assert marker["source"] == source_record
+
+
+def test_adopts_existing_commit_after_annotation_gap(tmp_path, source_record):
+    destination = tmp_path / source_record["relativePath"]
+    make_zarr_v2(destination)
+    marker = {
+        "markerSchema": 1,
+        "state": "committed",
+        "source": source_record,
+    }
+    (destination / CANONICAL_MARKER_NAME).write_text(
+        json.dumps(marker), encoding="utf-8"
+    )
+    store = CanonicalStore(tmp_path)
+
+    adopted = store.adopt(source_record)
+
+    assert adopted == destination
+
+
+def test_rejects_marker_for_different_omero_object(tmp_path, source_record):
+    destination = tmp_path / source_record["relativePath"]
+    make_zarr_v2(destination)
+    wrong = dict(source_record, sourceObjectId=999)
+    marker = {"markerSchema": 1, "state": "committed", "source": wrong}
+    (destination / CANONICAL_MARKER_NAME).write_text(
+        json.dumps(marker), encoding="utf-8"
+    )
+    store = CanonicalStore(tmp_path)
+
+    with pytest.raises(InvalidCanonicalStore, match="does not match"):
+        store.adopt(source_record)
+
+
+def test_accepts_bioformats2raw_layout_three_root(tmp_path, source_record):
+    destination = tmp_path / source_record["relativePath"]
+    (destination / "OME").mkdir(parents=True)
+    (destination / "OME/METADATA.ome.xml").write_text(
+        "<OME/>", encoding="utf-8"
+    )
+    (destination / "0").mkdir()
+    (destination / "0/.zgroup").write_text(
+        '{"zarr_format": 2}', encoding="utf-8"
+    )
+    marker = {
+        "markerSchema": 1,
+        "state": "committed",
+        "source": source_record,
+    }
+    (destination / CANONICAL_MARKER_NAME).write_text(
+        json.dumps(marker), encoding="utf-8"
+    )
+
+    assert CanonicalStore(tmp_path).adopt(source_record) == destination
+
+
+def test_creation_lock_is_exclusive(tmp_path, source_record):
+    store = CanonicalStore(tmp_path)
+
+    with store.creation_lock(source_record):
+        with pytest.raises(CanonicalCreationLocked):
+            with store.creation_lock(source_record):
+                pass

--- a/tests/unittests/test_canonical_store.py
+++ b/tests/unittests/test_canonical_store.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import importlib.util
 from pathlib import Path
@@ -98,6 +99,35 @@ def test_atomically_promotes_zarr_with_committed_marker(
     assert committed == tmp_path / source_record["relativePath"]
     assert committed.is_dir()
     assert not staging.exists()
+    marker = json.loads(
+        (committed / CANONICAL_MARKER_NAME).read_text(encoding="utf-8")
+    )
+    assert marker["state"] == "committed"
+    assert marker["source"] == source_record
+
+
+def test_promotes_across_filesystems_via_destination_staging(
+    tmp_path, source_record, monkeypatch
+):
+    store = CanonicalStore(tmp_path / "managed")
+    staging = tmp_path / "task" / "staging.ome.zarr"
+    make_zarr_v2(staging)
+    destination = store.destination_for(source_record)
+    real_replace = canonical_store.os.replace
+
+    def replace_with_cross_device_boundary(source, target):
+        if Path(source) == staging and Path(target) == destination:
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        return real_replace(source, target)
+
+    monkeypatch.setattr(canonical_store.os, "replace", replace_with_cross_device_boundary)
+
+    committed = store.commit(staging, source_record)
+
+    assert committed == destination
+    assert committed.is_dir()
+    assert not staging.exists()
+    assert not list(destination.parent.glob(f".{destination.name}.staging-*"))
     marker = json.loads(
         (committed / CANONICAL_MARKER_NAME).read_text(encoding="utf-8")
     )

--- a/tests/unittests/test_ingest_tracker.py
+++ b/tests/unittests/test_ingest_tracker.py
@@ -53,7 +53,12 @@ def test_log_ingestion_step(setup_database):
         'UUID': '123e4567-e89b-12d3-a456-426614174000',
         'DestinationID': 'test_dataset_id',  # Added missing field
         'Files': ["/path/to/test_file.tif", "/path/to/second/file.qptiff"],
-        'file_names': ["test_file.tif", "file.qptiff"]
+        'file_names': ["test_file.tif", "file.qptiff"],
+        'ImportOptions': {
+            'schema': 1,
+            'platePixelSource': 'label',
+            'plateLabelName': 'nuclei',
+        },
     }
     
     stage = STAGE_IMPORTED
@@ -81,6 +86,7 @@ def test_log_ingestion_step(setup_database):
         assert result.stage == stage
         assert result.uuid == order_info['UUID']
         assert json.loads(result.files) == order_info['Files']
+        assert json.loads(result.import_options) == order_info['ImportOptions']
         
     # Close the engine explicitly to release resources
     engine.dispose()

--- a/tests/unittests/test_lifecycle.py
+++ b/tests/unittests/test_lifecycle.py
@@ -1,0 +1,203 @@
+import json
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from biomero_schema.imports import (
+    ImportOptionsEnvelope,
+    ShallowZarrImportOperation,
+)
+from biomero_schema.zarr import (
+    CanonicalInputManifest,
+    CanonicalZarrSource,
+    PixelIdentity,
+    ShallowCollection,
+    ShallowImageReference,
+    ZarrLabelComponent,
+)
+
+from biomero_importer.utils.lifecycle import ImportLifecycleEngine
+from biomero_importer.utils.importer import DataPackageImporter
+from biomero_importer.utils.result_zarr import (
+    NormalizedShallowResult,
+    ReturnedZarrDecision,
+)
+
+
+WORKFLOW_ID = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+
+def _identity(node_path=".", role="image"):
+    return PixelIdentity(
+        nodePath=node_path,
+        role=role,
+        iscc="ISCC:KSUM",
+        dataCode="ISCC:GDATA",
+        instanceCode="ISCC:IINSTANCE",
+        toolVersion="0.1.0",
+        imagewalkRevision="iscc-bio/0.1.0@revision",
+        shape=(1, 1, 8, 8),
+        dtype="uint16",
+        axes=("t", "c", "y", "x"),
+    )
+
+
+def _source():
+    return CanonicalZarrSource(
+        storageRoot="group-0-data",
+        relativePath=".processed/source.ome.zarr",
+        nodePath=".",
+        sourceObjectType="Image",
+        sourceObjectId=1,
+        sourceGeneration=1,
+        interchangeProfile="ngff-0.4-zarr-v2",
+        pixelIdentity=_identity(),
+        pixelIdentityOrigin="omero-pixels",
+        canonicalPixelVerified=True,
+    )
+
+
+def _collection():
+    label = ZarrLabelComponent(
+        logicalNodePath="labels/nuclei",
+        pixelIdentity=_identity("labels/nuclei", "label"),
+    )
+    return ShallowCollection(
+        workflowId=WORKFLOW_ID,
+        transferArtifact="result.zarr",
+        interchangeProfile="ngff-0.4-zarr-v2",
+        images=(ShallowImageReference(
+            imageNodePath=".",
+            source=_source(),
+            returnedPixelIdentity=_identity(),
+            labelNodePaths=("labels/nuclei",),
+            labelComponents=(label,),
+        ),),
+    )
+
+
+def _options():
+    operation = ShallowZarrImportOperation(
+        canonicalInputs=CanonicalInputManifest(
+            workflowId=WORKFLOW_ID,
+            exportTaskId=UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            inputs=(),
+        )
+    )
+    return ImportOptionsEnvelope(operations=(operation,))
+
+
+def _zarr(tmp_path):
+    root = tmp_path / "result.zarr"
+    root.mkdir()
+    (root / ".zattrs").write_text("{}", encoding="utf-8")
+    (root / "labels" / "nuclei").mkdir(parents=True)
+    return root
+
+
+def test_no_operations_preserve_paths_without_execution(tmp_path):
+    path = tmp_path / "input.tif"
+
+    plan = ImportLifecycleEngine().prepare([path], None)
+
+    assert [item.path for item in plan.items] == [path]
+    assert [item.role for item in plan.items] == ["input"]
+    assert plan.changed is False
+
+
+def test_shallow_operation_is_disabled_by_default(tmp_path, monkeypatch):
+    monkeypatch.delenv("BIOMERO_SHALLOW_ZARR", raising=False)
+
+    with pytest.raises(ValueError, match="disabled"):
+        ImportLifecycleEngine().prepare([_zarr(tmp_path)], _options())
+
+
+def test_eligible_image_becomes_label_registration_view(tmp_path, monkeypatch):
+    root = _zarr(tmp_path)
+    collection = _collection()
+    decision = ReturnedZarrDecision(
+        store_path=root,
+        outcome="eligible",
+        reason="matched",
+        matched_inputs=(),
+    )
+    monkeypatch.setenv("BIOMERO_SHALLOW_ZARR", "true")
+    monkeypatch.setattr(
+        "biomero_importer.utils.lifecycle.evaluate_returned_zarr",
+        lambda *args, **kwargs: decision,
+    )
+    monkeypatch.setattr(
+        "biomero_importer.utils.lifecycle.normalize_returned_zarr",
+        lambda *args, **kwargs: NormalizedShallowResult(
+            store_path=root,
+            collection=collection,
+            bytes_before=None,
+            bytes_after=None,
+        ),
+    )
+
+    plan = ImportLifecycleEngine().prepare([root], _options())
+
+    assert [(item.path, item.role) for item in plan.items] == [
+        (root / "labels" / "nuclei", "image-label")
+    ]
+    assert plan.decisions == (decision,)
+
+
+def test_existing_manifest_is_idempotently_reused(tmp_path, monkeypatch):
+    root = _zarr(tmp_path)
+    (root / ".biomero-shallow.json").write_text(
+        json.dumps(_collection().to_dict()),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("BIOMERO_SHALLOW_ZARR", "true")
+    monkeypatch.setattr(
+        "biomero_importer.utils.lifecycle.evaluate_returned_zarr",
+        lambda *args, **kwargs: pytest.fail("must not re-evaluate"),
+    )
+
+    plan = ImportLifecycleEngine().prepare([root], _options())
+
+    assert [item.path for item in plan.items] == [
+        root / "labels" / "nuclei"
+    ]
+    assert plan.decisions == ()
+
+
+def test_prepared_views_use_existing_upload_path_and_restore_envelope(tmp_path):
+    root = _zarr(tmp_path)
+    plan = ImportLifecycleEngine().prepare([root], None)
+    importer = DataPackageImporter.__new__(DataPackageImporter)
+    importer.data_package = {"ImportOptions": {"schema": 2, "operations": []}}
+    importer.logger = __import__("logging").getLogger(__name__)
+    calls = []
+
+    def upload_files(conn, files, **targets):
+        calls.append((
+            files,
+            targets,
+            importer.data_package["ImportOptions"],
+        ))
+        return [(files[0], 1, Path(files[0]).name, 1)], []
+
+    importer.upload_files = upload_files
+
+    successful, failed = importer.upload_prepared_plan(
+        object(),
+        plan,
+        dataset_id=1,
+    )
+
+    assert len(successful) == 1
+    assert failed == []
+    assert calls[0][0] == [str(root)]
+    assert calls[0][2] == {
+        "schema": 1,
+        "platePixelSource": "source",
+        "plateLabelName": None,
+    }
+    assert importer.data_package["ImportOptions"] == {
+        "schema": 2,
+        "operations": [],
+    }

--- a/tests/unittests/test_pixel_identity.py
+++ b/tests/unittests/test_pixel_identity.py
@@ -1,6 +1,7 @@
 import importlib.util
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 MODULE_PATH = (
@@ -145,7 +146,7 @@ def test_builds_identity_from_public_iscc_bio_api(tmp_path):
         coordinate_transformations=({"type": "scale", "scale": [1, 1, 1, 2, 2]},),
     )
 
-    assert calls == [(zarr, "zarr")]
+    assert calls == [(zarr, "bioio")]
     assert identity.iscc_code == "ISCC:KSUM"
     assert identity.data_code == "ISCC:GDATA"
     assert identity.instance_code == "ISCC:IINSTANCE"
@@ -155,6 +156,54 @@ def test_builds_identity_from_public_iscc_bio_api(tmp_path):
     )
     assert identity.node_path == "."
     assert identity.shape == (1, 2, 3, 16, 32)
+
+
+def test_default_provider_hashes_standard_numeric_pyramid(tmp_path):
+    pytest.importorskip("iscc_bio")
+    zarr = pytest.importorskip("zarr")
+
+    root = tmp_path / "input.ome.zarr"
+    group = zarr.open_group(root, mode="w", zarr_format=2)
+    group.create_array(
+        "0",
+        data=np.arange(60, dtype="uint16").reshape(1, 3, 1, 4, 5),
+        chunks=(1, 1, 1, 4, 5),
+    )
+    group.attrs["multiscales"] = [
+        {
+            "version": "0.4",
+            "axes": [
+                {"name": "t", "type": "time"},
+                {"name": "c", "type": "channel"},
+                {"name": "z", "type": "space"},
+                {"name": "y", "type": "space"},
+                {"name": "x", "type": "space"},
+            ],
+            "datasets": [
+                {
+                    "path": "0",
+                    "coordinateTransformations": [
+                        {"type": "scale", "scale": [1, 1, 1, 1, 1]}
+                    ],
+                }
+            ],
+        }
+    ]
+    guard = read_zarr_v2_semantic_guard(root, ".")
+
+    identity = IsccBioIdentityProvider().generate(
+        root,
+        node_path=".",
+        role="image",
+        shape=guard.shape,
+        dtype=guard.dtype,
+        axes=guard.axes,
+        coordinate_transformations=guard.coordinate_transformations,
+    )
+
+    assert identity.instance_code == (
+        "ISCC:IAD3A4P5I72SL7N754WGCDJJXO36V3EI65WIKFWN7DFJWT2KPDQUT6I"
+    )
 
 
 def test_targets_an_explicit_nested_zarr_node(tmp_path):
@@ -178,7 +227,7 @@ def test_targets_an_explicit_nested_zarr_node(tmp_path):
         axes=("t", "c", "z", "y", "x"),
     )
 
-    assert calls == [(node, "zarr")]
+    assert calls == [(node, "bioio")]
     assert identity.node_path == "A/1/0"
 
 

--- a/tests/unittests/test_pixel_identity.py
+++ b/tests/unittests/test_pixel_identity.py
@@ -182,6 +182,53 @@ def test_targets_an_explicit_nested_zarr_node(tmp_path):
     assert identity.node_path == "A/1/0"
 
 
+def test_builds_omero_identity_through_same_public_api():
+    connection = object()
+    calls = []
+
+    def generate(*args, **kwargs):
+        calls.append((args, kwargs))
+        return [biocode_result()]
+
+    provider = IsccBioIdentityProvider(
+        generate_biocode=generate,
+        tool_version="0.1.0",
+    )
+
+    identity = provider.generate_omero(
+        connection,
+        image_id=3207,
+        node_path=".",
+        role="image",
+        shape=(1, 2, 3, 16, 32),
+        dtype="uint16",
+        axes=("t", "c", "z", "y", "x"),
+        coordinate_transformations=({"type": "scale", "scale": [1, 1, 1, 2, 2]},),
+    )
+
+    assert calls == [((), {"conn": connection, "iid": 3207})]
+    assert identity.instance_code == "ISCC:IINSTANCE"
+    assert identity.shape == (1, 2, 3, 16, 32)
+
+
+def test_omero_identity_rejects_invalid_image_id():
+    provider = IsccBioIdentityProvider(
+        generate_biocode=lambda *args, **kwargs: [biocode_result()],
+        tool_version="0.1.0",
+    )
+
+    with pytest.raises(PixelIdentityError, match="positive"):
+        provider.generate_omero(
+            object(),
+            image_id=0,
+            node_path=".",
+            role="image",
+            shape=(8, 8),
+            dtype="uint8",
+            axes=("y", "x"),
+        )
+
+
 @pytest.mark.parametrize("node_path", ["../escape", "/absolute", r"A\1\0"])
 def test_rejects_unsafe_node_path(tmp_path, node_path):
     provider = IsccBioIdentityProvider(

--- a/tests/unittests/test_pixel_identity.py
+++ b/tests/unittests/test_pixel_identity.py
@@ -206,7 +206,7 @@ def test_default_provider_hashes_standard_numeric_pyramid(tmp_path):
     )
 
 
-def test_targets_an_explicit_nested_zarr_node(tmp_path):
+def test_targets_an_explicit_nested_zarr_node(tmp_path, monkeypatch):
     root = tmp_path / "plate.ome.zarr"
     node = root / "A" / "1" / "0"
     node.mkdir(parents=True)
@@ -217,6 +217,12 @@ def test_targets_an_explicit_nested_zarr_node(tmp_path):
         ),
         tool_version="0.1.0",
     )
+    aliases = []
+
+    def make_alias(source, alias, *, target_is_directory):
+        aliases.append((source, alias, target_is_directory))
+
+    monkeypatch.setattr(pixel_identity.os, "symlink", make_alias)
 
     identity = provider.generate(
         root,
@@ -227,7 +233,12 @@ def test_targets_an_explicit_nested_zarr_node(tmp_path):
         axes=("t", "c", "z", "y", "x"),
     )
 
-    assert calls == [(node, "bioio")]
+    assert len(calls) == 1
+    assert calls[0][0].name == "image.ome.zarr"
+    assert calls[0][1] == "bioio"
+    assert aliases[0][0] == node
+    assert aliases[0][1] == calls[0][0]
+    assert aliases[0][2] is True
     assert identity.node_path == "A/1/0"
 
 

--- a/tests/unittests/test_pixel_identity.py
+++ b/tests/unittests/test_pixel_identity.py
@@ -15,11 +15,110 @@ SPEC.loader.exec_module(pixel_identity)
 
 IsccBioIdentityProvider = pixel_identity.IsccBioIdentityProvider
 PixelIdentityError = pixel_identity.PixelIdentityError
+read_zarr_v2_semantic_guard = pixel_identity.read_zarr_v2_semantic_guard
 pixel_identities_match = pixel_identity.pixel_identities_match
 
 
 def biocode_result(code="ISCC:KSUM", data="ISCC:GDATA", instance="ISCC:IINSTANCE"):
     return {"iscc_code": code, "units": [data, instance]}
+
+
+def write_json(path, value):
+    import json
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def make_ngff_v2_image(root, node_path="."):
+    node = root if node_path == "." else root / node_path
+    write_json(node / ".zgroup", {"zarr_format": 2})
+    write_json(
+        node / ".zattrs",
+        {
+            "multiscales": [
+                {
+                    "version": "0.4",
+                    "axes": [
+                        {"name": "t", "type": "time"},
+                        {"name": "c", "type": "channel"},
+                        {"name": "z", "type": "space"},
+                        {"name": "y", "type": "space"},
+                        {"name": "x", "type": "space"},
+                    ],
+                    "datasets": [
+                        {
+                            "path": "0",
+                            "coordinateTransformations": [
+                                {"type": "scale", "scale": [1, 1, 2, 0.5, 0.5]}
+                            ],
+                        },
+                        {"path": "1"},
+                    ],
+                }
+            ]
+        },
+    )
+    write_json(
+        node / "0" / ".zarray",
+        {"zarr_format": 2, "shape": [1, 2, 3, 16, 32], "dtype": "<u2"},
+    )
+    return node
+
+
+def test_reads_ngff_04_zarr_v2_semantic_guard(tmp_path):
+    root = tmp_path / "input.ome.zarr"
+    make_ngff_v2_image(root)
+
+    guard = read_zarr_v2_semantic_guard(root, ".")
+
+    assert guard.shape == (1, 2, 3, 16, 32)
+    assert guard.dtype == "uint16"
+    assert guard.axes == ("t", "c", "z", "y", "x")
+    assert guard.coordinate_transformations == (
+        {"type": "scale", "scale": [1, 1, 2, 0.5, 0.5]},
+    )
+    assert guard.ngff_version == "0.4"
+    assert guard.zarr_format == 2
+
+
+def test_reads_nested_plate_image_node(tmp_path):
+    root = tmp_path / "plate.ome.zarr"
+    make_ngff_v2_image(root, "A/1/0")
+
+    guard = read_zarr_v2_semantic_guard(root, "A/1/0")
+
+    assert guard.shape == (1, 2, 3, 16, 32)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda node: (node / ".zattrs").unlink(), "metadata"),
+        (
+            lambda node: write_json(
+                node / ".zattrs", {"multiscales": [{"version": "0.5"}]}
+            ),
+            "NGFF 0.4",
+        ),
+        (
+            lambda node: write_json(
+                node / "0" / ".zarray",
+                {"zarr_format": 3, "shape": [8, 8], "dtype": "uint8"},
+            ),
+            "Zarr v2",
+        ),
+    ],
+)
+def test_semantic_guard_fails_closed_for_unsupported_metadata(
+    tmp_path, mutate, message
+):
+    root = tmp_path / "input.ome.zarr"
+    node = make_ngff_v2_image(root)
+    mutate(node)
+
+    with pytest.raises(PixelIdentityError, match=message):
+        read_zarr_v2_semantic_guard(root, ".")
 
 
 def test_builds_identity_from_public_iscc_bio_api(tmp_path):

--- a/tests/unittests/test_pixel_identity.py
+++ b/tests/unittests/test_pixel_identity.py
@@ -1,0 +1,189 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).parents[2]
+    / "biomero_importer"
+    / "utils"
+    / "pixel_identity.py"
+)
+SPEC = importlib.util.spec_from_file_location("pixel_identity", MODULE_PATH)
+pixel_identity = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(pixel_identity)
+
+IsccBioIdentityProvider = pixel_identity.IsccBioIdentityProvider
+PixelIdentityError = pixel_identity.PixelIdentityError
+pixel_identities_match = pixel_identity.pixel_identities_match
+
+
+def biocode_result(code="ISCC:KSUM", data="ISCC:GDATA", instance="ISCC:IINSTANCE"):
+    return {"iscc_code": code, "units": [data, instance]}
+
+
+def test_builds_identity_from_public_iscc_bio_api(tmp_path):
+    zarr = tmp_path / "input.ome.zarr"
+    zarr.mkdir()
+    calls = []
+
+    def generate(source, *, source_type):
+        calls.append((source, source_type))
+        return [biocode_result()]
+
+    provider = IsccBioIdentityProvider(
+        generate_biocode=generate,
+        tool_version="0.1.0",
+    )
+
+    identity = provider.generate(
+        zarr,
+        node_path=".",
+        role="image",
+        shape=(1, 2, 3, 16, 32),
+        dtype="uint16",
+        axes=("t", "c", "z", "y", "x"),
+        coordinate_transformations=({"type": "scale", "scale": [1, 1, 1, 2, 2]},),
+    )
+
+    assert calls == [(zarr, "zarr")]
+    assert identity.iscc_code == "ISCC:KSUM"
+    assert identity.data_code == "ISCC:GDATA"
+    assert identity.instance_code == "ISCC:IINSTANCE"
+    assert identity.tool_version == "0.1.0"
+    assert identity.imagewalk_revision == (
+        "iscc-bio/0.1.0@c536d7699b7d25592bfe5c91c947b749344b6914"
+    )
+    assert identity.node_path == "."
+    assert identity.shape == (1, 2, 3, 16, 32)
+
+
+def test_targets_an_explicit_nested_zarr_node(tmp_path):
+    root = tmp_path / "plate.ome.zarr"
+    node = root / "A" / "1" / "0"
+    node.mkdir(parents=True)
+    calls = []
+    provider = IsccBioIdentityProvider(
+        generate_biocode=lambda source, *, source_type: (
+            calls.append((source, source_type)) or [biocode_result()]
+        ),
+        tool_version="0.1.0",
+    )
+
+    identity = provider.generate(
+        root,
+        node_path="A/1/0",
+        role="image",
+        shape=(1, 1, 1, 8, 8),
+        dtype="uint8",
+        axes=("t", "c", "z", "y", "x"),
+    )
+
+    assert calls == [(node, "zarr")]
+    assert identity.node_path == "A/1/0"
+
+
+@pytest.mark.parametrize("node_path", ["../escape", "/absolute", r"A\1\0"])
+def test_rejects_unsafe_node_path(tmp_path, node_path):
+    provider = IsccBioIdentityProvider(
+        generate_biocode=lambda *args, **kwargs: [biocode_result()],
+        tool_version="0.1.0",
+    )
+
+    with pytest.raises(PixelIdentityError, match="node path"):
+        provider.generate(
+            tmp_path,
+            node_path=node_path,
+            role="image",
+            shape=(8, 8),
+            dtype="uint8",
+            axes=("y", "x"),
+        )
+
+
+def test_rejects_missing_or_ambiguous_scene(tmp_path):
+    zarr = tmp_path / "input.ome.zarr"
+    zarr.mkdir()
+
+    for results in ([], [biocode_result(), biocode_result(code="ISCC:KOTHER")]):
+        provider = IsccBioIdentityProvider(
+            generate_biocode=lambda *args, _results=results, **kwargs: _results,
+            tool_version="0.1.0",
+        )
+        with pytest.raises(PixelIdentityError, match="exactly one scene"):
+            provider.generate(
+                zarr,
+                node_path=".",
+                role="image",
+                shape=(8, 8),
+                dtype="uint8",
+                axes=("y", "x"),
+            )
+
+
+def test_rejects_unexpected_upstream_result(tmp_path):
+    zarr = tmp_path / "input.ome.zarr"
+    zarr.mkdir()
+    provider = IsccBioIdentityProvider(
+        generate_biocode=lambda *args, **kwargs: [
+            {"iscc_code": "ISCC:KSUM", "units": ["ISCC:GDATA"]}
+        ],
+        tool_version="0.1.0",
+    )
+
+    with pytest.raises(PixelIdentityError, match="Data and Instance"):
+        provider.generate(
+            zarr,
+            node_path=".",
+            role="image",
+            shape=(8, 8),
+            dtype="uint8",
+            axes=("y", "x"),
+        )
+
+
+def test_exact_match_requires_instance_code_and_semantic_guard(tmp_path):
+    zarr = tmp_path / "input.ome.zarr"
+    zarr.mkdir()
+    provider = IsccBioIdentityProvider(
+        generate_biocode=lambda *args, **kwargs: [biocode_result()],
+        tool_version="0.1.0",
+    )
+    first = provider.generate(
+        zarr,
+        node_path=".",
+        role="image",
+        shape=(8, 8),
+        dtype="uint8",
+        axes=("y", "x"),
+    )
+    same = first.model_copy(update={"iscc_code": "ISCC:KDIFFERENT"})
+    changed_instance = first.model_copy(update={"instance_code": "ISCC:IDIFFERENT"})
+    changed_shape = first.model_copy(update={"shape": (4, 16)})
+
+    assert pixel_identities_match(first, same)
+    assert not pixel_identities_match(first, changed_instance)
+    assert not pixel_identities_match(first, changed_shape)
+
+
+def test_default_provider_loads_upstream_lazily(monkeypatch):
+    imported = []
+
+    def fail_import(name):
+        imported.append(name)
+        raise ImportError("not installed")
+
+    monkeypatch.setattr(pixel_identity, "import_module", fail_import)
+    provider = IsccBioIdentityProvider()
+
+    with pytest.raises(PixelIdentityError, match="identity extra"):
+        provider.generate(
+            Path("missing.zarr"),
+            node_path=".",
+            role="image",
+            shape=(8, 8),
+            dtype="uint8",
+            axes=("y", "x"),
+        )
+
+    assert imported == ["iscc_bio.api"]

--- a/tests/unittests/test_result_zarr.py
+++ b/tests/unittests/test_result_zarr.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from threading import Barrier, Lock, get_ident
 from uuid import UUID
 
 from biomero_schema.zarr import (
@@ -191,6 +192,21 @@ class NodeIdentityProvider:
         return self.identities[kwargs["node_path"]]
 
 
+class ConcurrentNodeIdentityProvider(NodeIdentityProvider):
+    def __init__(self, identities, parties):
+        super().__init__(identities)
+        self.barrier = Barrier(parties)
+        self.lock = Lock()
+        self.thread_ids = set()
+
+    def generate(self, root, **kwargs):
+        with self.lock:
+            self.calls.append((Path(root), kwargs))
+            self.thread_ids.add(get_ident())
+        self.barrier.wait(timeout=5)
+        return self.identities[kwargs["node_path"]]
+
+
 def test_discovers_image_and_declared_labels(tmp_path):
     root = tmp_path / "result.zarr"
     _make_image(root, labels=("cells", "nuclei"))
@@ -216,6 +232,58 @@ def test_discovers_plate_image_level_labels(tmp_path):
         ("A/1/0", "image"),
         ("A/1/0/labels/cells", "label"),
     ]
+
+
+def test_evaluation_hashes_plate_images_and_labels_concurrently_in_order(
+    tmp_path,
+):
+    root = tmp_path / "plate.zarr"
+    _make_plate(root, {
+        "A/1/0": ("cells",),
+        "B/1/0": ("cells",),
+    })
+    provider = ConcurrentNodeIdentityProvider({
+        "A/1/0": _identity("ISCC:IA", "A/1/0"),
+        "B/1/0": _identity("ISCC:IB", "B/1/0"),
+        "A/1/0/labels/cells": _identity(
+            "ISCC:IALABEL",
+            "A/1/0/labels/cells",
+            "label",
+        ),
+        "B/1/0/labels/cells": _identity(
+            "ISCC:IBLABEL",
+            "B/1/0/labels/cells",
+            "label",
+        ),
+    }, parties=2)
+
+    decision = evaluate_returned_zarr(
+        root,
+        _manifest(_plate_input()),
+        identity_provider=provider,
+        identity_workers=2,
+    )
+
+    assert decision.eligible
+    assert tuple(
+        identity.node_path for identity in decision.image_identities
+    ) == ("A/1/0", "B/1/0")
+    assert tuple(
+        identity.node_path for identity in decision.label_identities
+    ) == (
+        "A/1/0/labels/cells",
+        "B/1/0/labels/cells",
+    )
+    assert len(provider.thread_ids) == 2
+
+
+def test_evaluation_rejects_invalid_identity_worker_count(tmp_path):
+    try:
+        evaluate_returned_zarr(tmp_path, None, identity_workers=0)
+    except ValueError as exc:
+        assert "positive integer" in str(exc)
+    else:
+        raise AssertionError("invalid identity worker count was accepted")
 
 
 def test_unchanged_plate_without_labels_is_a_passthrough(tmp_path):

--- a/tests/unittests/test_result_zarr.py
+++ b/tests/unittests/test_result_zarr.py
@@ -6,7 +6,9 @@ from biomero_schema.zarr import (
     CanonicalInput,
     CanonicalInputManifest,
     CanonicalZarrSource,
+    ManagedZarrNode,
     PixelIdentity,
+    ZarrLabelComponent,
 )
 
 from biomero_importer.utils.result_zarr import (
@@ -52,10 +54,14 @@ def _make_image(root: Path, node_path=".", labels=()) -> None:
             _make_image(root, f"{node_path}/labels/{label}".replace("./", ""))
 
 
-def _identity(instance="ISCC:IINSTANCE", node_path=".") -> PixelIdentity:
+def _identity(
+    instance="ISCC:IINSTANCE",
+    node_path=".",
+    role="image",
+) -> PixelIdentity:
     return PixelIdentity(
         node_path=node_path,
-        role="image",
+        role=role,
         iscc_code="ISCC:KSUM",
         data_code="ISCC:GDATA",
         instance_code=instance,
@@ -75,13 +81,19 @@ def _manifest(*items) -> CanonicalInputManifest:
     )
 
 
-def _input(ordinal, artifact=None, instance="ISCC:IINSTANCE") -> CanonicalInput:
+def _input(
+    ordinal,
+    artifact=None,
+    instance="ISCC:IINSTANCE",
+    labels=(),
+) -> CanonicalInput:
     identity = _identity(instance)
     return CanonicalInput(
         ordinal=ordinal,
         selected_object_type="Image",
         selected_object_id=ordinal + 1,
         transfer_artifact=artifact,
+        labels=labels,
         source=CanonicalZarrSource(
             storage_root="group-0-data",
             relative_path=f".processed/Image-{ordinal + 1}.ome.zarr",
@@ -108,6 +120,16 @@ class IdentityProvider:
             "node_path": kwargs["node_path"],
             "role": kwargs["role"],
         })
+
+
+class NodeIdentityProvider:
+    def __init__(self, identities):
+        self.identities = identities
+        self.calls = []
+
+    def generate(self, root, **kwargs):
+        self.calls.append((Path(root), kwargs))
+        return self.identities[kwargs["node_path"]]
 
 
 def test_discovers_image_and_declared_labels(tmp_path):
@@ -155,6 +177,70 @@ def test_transfer_artifact_disambiguates_duplicate_input_identities(tmp_path):
     assert decision.eligible
     assert decision.reason == "input-image-unchanged"
     assert decision.matched_inputs[0].ordinal == 1
+
+
+def test_classifies_inherited_new_and_changed_labels(tmp_path):
+    root = tmp_path / "result.zarr"
+    _make_image(root, labels=("nuclei", "cells", "foci"))
+    managed_nuclei = ZarrLabelComponent(
+        logical_node_path="labels/nuclei",
+        pixel_identity=_identity(
+            "ISCC:INUCLEI",
+            "labels/nuclei",
+            "label",
+        ),
+        source=ManagedZarrNode(
+            storage_root="import-mount-data",
+            relative_path="Project A/.analyzed/first/result.zarr",
+            node_path="labels/nuclei",
+        ),
+    )
+    managed_foci = ZarrLabelComponent(
+        logical_node_path="labels/foci",
+        pixel_identity=_identity("ISCC:IOLD", "labels/foci", "label"),
+        source=ManagedZarrNode(
+            storage_root="import-mount-data",
+            relative_path="Project A/.analyzed/first/result.zarr",
+            node_path="labels/foci",
+        ),
+    )
+    provider = NodeIdentityProvider({
+        ".": _identity(),
+        "labels/nuclei": _identity(
+            "ISCC:INUCLEI",
+            "labels/nuclei",
+            "label",
+        ),
+        "labels/cells": _identity(
+            "ISCC:ICELLS",
+            "labels/cells",
+            "label",
+        ),
+        "labels/foci": _identity(
+            "ISCC:ICHANGED",
+            "labels/foci",
+            "label",
+        ),
+    })
+
+    decision = evaluate_returned_zarr(
+        root,
+        _manifest(_input(
+            0,
+            "result.zarr",
+            labels=(managed_nuclei, managed_foci),
+        )),
+        identity_provider=provider,
+    )
+
+    assert decision.eligible
+    assert len(decision.label_identities) == 3
+    components = {
+        item.logical_node_path: item for item in decision.label_components
+    }
+    assert components["labels/nuclei"].source == managed_nuclei.source
+    assert components["labels/cells"].source is None
+    assert components["labels/foci"].source is None
 
 
 def test_legacy_duplicate_identities_are_ambiguous(tmp_path):
@@ -257,6 +343,10 @@ def test_normalization_transaction_keeps_labels_and_omits_image_chunks(
     )
     assert manifest["model"] == "rfc8-shallow-copy"
     assert manifest["images"][0]["source"]["sourceObjectId"] == 1
+    assert manifest["images"][0]["labelComponents"][0]["source"] is None
+    assert manifest["images"][0]["labelComponents"][0][
+        "pixelIdentity"
+    ]["role"] == "label"
     assert "multiscales" not in json.loads(
         (root / ".zattrs").read_text(encoding="utf-8")
     )

--- a/tests/unittests/test_result_zarr.py
+++ b/tests/unittests/test_result_zarr.py
@@ -558,6 +558,69 @@ def test_resolves_primary_and_label_registration_views(tmp_path):
     assert label.reference == primary.reference
 
 
+def test_resolves_source_and_label_backed_plate_registration(tmp_path):
+    import_root = tmp_path / "data"
+    group_root = import_root / "Project A"
+    canonical = group_root / ".processed/Plate-1.ome.zarr"
+    returned = import_root / "results/plate.zarr"
+    labels_by_image = {
+        "A/1/0": ("nuclei",),
+        "B/1/0": ("nuclei",),
+    }
+    _make_plate(canonical)
+    _make_plate(returned, labels_by_image)
+    provider = NodeIdentityProvider({
+        "A/1/0": _identity("ISCC:IA", "A/1/0"),
+        "B/1/0": _identity("ISCC:IB", "B/1/0"),
+        "A/1/0/labels/nuclei": _identity(
+            "ISCC:ILABELA", "A/1/0/labels/nuclei", "label"
+        ),
+        "B/1/0/labels/nuclei": _identity(
+            "ISCC:ILABELB", "B/1/0/labels/nuclei", "label"
+        ),
+    })
+    decision = evaluate_returned_zarr(
+        returned,
+        _manifest(_plate_input()),
+        identity_provider=provider,
+    )
+    normalize_returned_zarr(
+        decision,
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    )
+    roots = {
+        "import-mount-data": import_root,
+        "group-0-data": group_root,
+    }
+
+    source = resolve_shallow_registration(
+        returned,
+        storage_roots=roots,
+        import_mount_path=import_root,
+    )
+    label = resolve_shallow_registration(
+        returned,
+        storage_roots=roots,
+        import_mount_path=import_root,
+        import_options={
+            "schema": 1,
+            "platePixelSource": "label",
+            "plateLabelName": "nuclei",
+        },
+    )
+
+    assert source.kind == "plate"
+    assert source.registration_path == canonical.resolve()
+    assert source.reference.source_object_id == 1
+    assert source.reference.image_node_count == 2
+    assert source.plate_label_paths == ()
+    assert dict(label.plate_label_paths) == {
+        "A/1/0": (returned / "A/1/0/labels/nuclei").resolve(),
+        "B/1/0": (returned / "B/1/0/labels/nuclei").resolve(),
+    }
+    assert label.plate_label_name == "nuclei"
+
+
 def test_shallow_registration_returns_none_outside_import_mount(tmp_path):
     assert resolve_shallow_registration(
         tmp_path / "outside.zarr",

--- a/tests/unittests/test_result_zarr.py
+++ b/tests/unittests/test_result_zarr.py
@@ -14,6 +14,7 @@ from biomero_importer.utils.result_zarr import (
     evaluate_returned_zarr,
     find_returned_zarr_stores,
     normalize_returned_zarr,
+    resolve_shallow_registration,
 )
 
 
@@ -186,7 +187,7 @@ def test_changed_pixels_keep_full_even_when_artifact_matches(tmp_path):
     assert decision.reason == "pixels-changed"
 
 
-def test_result_without_labels_is_not_eligible(tmp_path):
+def test_unchanged_result_without_labels_is_a_passthrough(tmp_path):
     root = tmp_path / "result.zarr"
     _make_image(root)
     provider = IdentityProvider(_identity())
@@ -198,8 +199,25 @@ def test_result_without_labels_is_not_eligible(tmp_path):
     )
 
     assert not decision.eligible
-    assert decision.reason == "no-label-nodes"
-    assert provider.calls == []
+    assert decision.unchanged_passthrough
+    assert decision.reason == "input-image-unchanged-no-labels"
+    assert len(provider.calls) == 1
+
+
+def test_changed_result_without_labels_is_kept_full(tmp_path):
+    root = tmp_path / "result.zarr"
+    _make_image(root)
+
+    decision = evaluate_returned_zarr(
+        root,
+        _manifest(_input(0, "result.zarr")),
+        identity_provider=IdentityProvider(_identity("ISCC:ICHANGED")),
+    )
+
+    assert not decision.eligible
+    assert not decision.unchanged_passthrough
+    assert decision.outcome == "keep-full"
+    assert decision.reason == "pixels-changed"
 
 
 def test_store_finder_prunes_nested_label_zarrs(tmp_path):
@@ -277,3 +295,51 @@ def test_normalization_restores_full_store_when_commit_rename_fails(tmp_path):
 
     assert original_chunk.read_bytes() == b"image-pixels" * 2048
     assert not (root / ".biomero-shallow.json").exists()
+
+
+def test_resolves_primary_and_label_registration_views(tmp_path):
+    import_root = tmp_path / "data"
+    group_root = import_root / "Project A"
+    returned = import_root / "results/result.zarr"
+    canonical = group_root / ".processed/Image-1.ome.zarr"
+    _make_image(returned, labels=("cells",))
+    _make_image(canonical)
+    decision = evaluate_returned_zarr(
+        returned,
+        _manifest(_input(0, "result.zarr")),
+        identity_provider=IdentityProvider(_identity()),
+    )
+    normalize_returned_zarr(
+        decision,
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    )
+    roots = {
+        "import-mount-data": import_root,
+        "group-0-data": group_root,
+    }
+
+    primary = resolve_shallow_registration(
+        returned,
+        storage_roots=roots,
+        import_mount_path=import_root,
+    )
+    label = resolve_shallow_registration(
+        returned / "labels/cells",
+        storage_roots=roots,
+        import_mount_path=import_root,
+    )
+
+    assert primary.kind == "primary"
+    assert primary.registration_path == canonical.resolve()
+    assert primary.reference.relative_path == "results/result.zarr"
+    assert primary.reference.label_node_paths == ("labels/cells",)
+    assert label.kind == "label"
+    assert label.registration_path == (returned / "labels/cells").resolve()
+    assert label.reference == primary.reference
+
+
+def test_shallow_registration_returns_none_outside_import_mount(tmp_path):
+    assert resolve_shallow_registration(
+        tmp_path / "outside.zarr",
+        import_mount_path=tmp_path / "data",
+    ) is None

--- a/tests/unittests/test_result_zarr.py
+++ b/tests/unittests/test_result_zarr.py
@@ -15,6 +15,7 @@ from biomero_importer.utils.result_zarr import (
     discover_ngff_nodes,
     evaluate_returned_zarr,
     find_returned_zarr_stores,
+    materialize_shallow_zarr,
     normalize_returned_zarr,
     resolve_shallow_registration,
 )
@@ -433,3 +434,82 @@ def test_shallow_registration_returns_none_outside_import_mount(tmp_path):
         tmp_path / "outside.zarr",
         import_mount_path=tmp_path / "data",
     ) is None
+
+
+def test_materializes_original_with_inherited_and_local_labels(tmp_path):
+    import_root = tmp_path / "data"
+    canonical = import_root / "Project A/.processed/Image-1.ome.zarr"
+    prior = import_root / "Project A/.analyzed/first/result.zarr"
+    returned = import_root / "results/result.zarr"
+    _make_image(canonical)
+    _make_image(prior, labels=("nuclei",))
+    _make_image(returned, labels=("nuclei", "cells"))
+    (prior / "labels/nuclei/0/0.0.0.0").write_bytes(b"prior-nuclei")
+    (returned / "labels/nuclei/0/0.0.0.0").write_bytes(
+        b"workflow-copy-of-nuclei"
+    )
+    (returned / "labels/cells/0/0.0.0.0").write_bytes(b"new-cells")
+    nuclei_identity = _identity(
+        "ISCC:INUCLEI", "labels/nuclei", "label"
+    )
+    input_nuclei = ZarrLabelComponent(
+        logical_node_path="labels/nuclei",
+        pixel_identity=nuclei_identity,
+        source=ManagedZarrNode(
+            storage_root="group-0-data",
+            relative_path=".analyzed/first/result.zarr",
+            node_path="labels/nuclei",
+        ),
+    )
+    provider = NodeIdentityProvider({
+        ".": _identity(),
+        "labels/nuclei": nuclei_identity,
+        "labels/cells": _identity(
+            "ISCC:ICELLS", "labels/cells", "label"
+        ),
+    })
+    decision = evaluate_returned_zarr(
+        returned,
+        _manifest(_input(
+            0,
+            "result.zarr",
+            labels=(input_nuclei,),
+        )),
+        identity_provider=provider,
+    )
+    normalize_returned_zarr(
+        decision,
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    )
+    roots = {
+        "import-mount-data": import_root,
+        "group-0-data": import_root / "Project A",
+    }
+    registration = resolve_shallow_registration(
+        returned / "labels/cells",
+        storage_roots=roots,
+        import_mount_path=import_root,
+    )
+    destination = tmp_path / "transfer/result.zarr"
+    destination.parent.mkdir()
+
+    result = materialize_shallow_zarr(
+        registration.reference,
+        destination,
+        roots,
+    )
+
+    assert (destination / "0/0.0.0.0").read_bytes() == b"image-pixels" * 2048
+    assert (
+        destination / "labels/nuclei/0/0.0.0.0"
+    ).read_bytes() == b"prior-nuclei"
+    assert (
+        destination / "labels/cells/0/0.0.0.0"
+    ).read_bytes() == b"new-cells"
+    assert json.loads(
+        (destination / "labels/.zattrs").read_text(encoding="utf-8")
+    ) == {"labels": ["nuclei", "cells"]}
+    assert all(label.source is not None for label in result.labels)
+    assert (
+        returned / "labels/nuclei/0/0.0.0.0"
+    ).read_bytes() == b"workflow-copy-of-nuclei"

--- a/tests/unittests/test_result_zarr.py
+++ b/tests/unittests/test_result_zarr.py
@@ -13,6 +13,7 @@ from biomero_importer.utils.result_zarr import (
     discover_ngff_nodes,
     evaluate_returned_zarr,
     find_returned_zarr_stores,
+    normalize_returned_zarr,
 )
 
 
@@ -42,6 +43,7 @@ def _make_image(root: Path, node_path=".", labels=()) -> None:
         "chunks": [1, 1, 8, 8],
         "dtype": "<u2",
     })
+    (node / "0" / "0.0.0.0").write_bytes(b"image-pixels" * 2048)
     if labels:
         _write_json(node / "labels" / ".zgroup", {"zarr_format": 2})
         _write_json(node / "labels" / ".zattrs", {"labels": list(labels)})
@@ -210,3 +212,68 @@ def test_store_finder_prunes_nested_label_zarrs(tmp_path):
         tmp_path / "second.zarr",
         outer,
     )
+
+
+def test_normalization_transaction_keeps_labels_and_omits_image_chunks(
+    tmp_path,
+):
+    root = tmp_path / "result.zarr"
+    _make_image(root, labels=("cells",))
+    label_chunk = root / "labels/cells/0/0.0.0.0"
+    label_chunk.write_bytes(b"label-pixels")
+    decision = evaluate_returned_zarr(
+        root,
+        _manifest(_input(0, "result.zarr")),
+        identity_provider=IdentityProvider(_identity()),
+    )
+
+    normalized = normalize_returned_zarr(
+        decision,
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    )
+
+    assert not (root / "0").exists()
+    assert label_chunk.read_bytes() == b"label-pixels"
+    manifest = json.loads(
+        (root / ".biomero-shallow.json").read_text(encoding="utf-8")
+    )
+    assert manifest["model"] == "rfc8-shallow-copy"
+    assert manifest["images"][0]["source"]["sourceObjectId"] == 1
+    assert "multiscales" not in json.loads(
+        (root / ".zattrs").read_text(encoding="utf-8")
+    )
+    assert normalized.bytes_after < normalized.bytes_before
+    assert not list(tmp_path.glob(".result.zarr.biomero-*"))
+
+
+def test_normalization_restores_full_store_when_commit_rename_fails(tmp_path):
+    root = tmp_path / "result.zarr"
+    _make_image(root, labels=("cells",))
+    original_chunk = root / "0/0.0.0.0"
+    decision = evaluate_returned_zarr(
+        root,
+        _manifest(_input(0, "result.zarr")),
+        identity_provider=IdentityProvider(_identity()),
+    )
+    calls = 0
+
+    def fail_second_replace(source, target):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("simulated commit failure")
+        source.replace(target)
+
+    try:
+        normalize_returned_zarr(
+            decision,
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            replace=fail_second_replace,
+        )
+    except OSError as exc:
+        assert "simulated commit failure" in str(exc)
+    else:
+        raise AssertionError("normalization unexpectedly succeeded")
+
+    assert original_chunk.read_bytes() == b"image-pixels" * 2048
+    assert not (root / ".biomero-shallow.json").exists()

--- a/tests/unittests/test_result_zarr.py
+++ b/tests/unittests/test_result_zarr.py
@@ -289,6 +289,35 @@ def test_normalizes_plate_images_and_retains_image_level_label(tmp_path):
     assert images["B/1/0"].label_node_paths == ()
 
 
+def test_normalizes_renamed_plate_output_by_pixel_identity(tmp_path):
+    root = tmp_path / "plate__segmentation.ome.zarr"
+    _make_plate(root, {"A/1/0": ("cells",)})
+    label_path = "A/1/0/labels/cells"
+    provider = NodeIdentityProvider({
+        "A/1/0": _identity("ISCC:IA", "A/1/0"),
+        "B/1/0": _identity("ISCC:IB", "B/1/0"),
+        label_path: _identity("ISCC:ICELLS", label_path, "label"),
+    })
+    decision = evaluate_returned_zarr(
+        root,
+        _manifest(_plate_input()),
+        identity_provider=provider,
+    )
+
+    normalized = normalize_returned_zarr(
+        decision,
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    )
+
+    assert decision.eligible
+    assert decision.matched_inputs[0].transfer_artifact == "plate.zarr"
+    assert normalized.collection.transfer_artifact == root.name
+    assert (root / ".biomero-shallow.json").is_file()
+    assert not (root / "A/1/0/0").exists()
+    assert not (root / "B/1/0/0").exists()
+    assert (root / label_path).is_dir()
+
+
 def test_transfer_artifact_disambiguates_duplicate_input_identities(tmp_path):
     root = tmp_path / "second.zarr"
     _make_image(root, labels=("cells",))

--- a/tests/unittests/test_result_zarr.py
+++ b/tests/unittests/test_result_zarr.py
@@ -510,9 +510,8 @@ def test_materializes_original_with_inherited_and_local_labels(tmp_path):
         (destination / "labels/.zattrs").read_text(encoding="utf-8")
     ) == {"labels": ["nuclei", "cells"]}
     assert all(label.source is not None for label in result.labels)
-    assert (
-        returned / "labels/nuclei/0/0.0.0.0"
-    ).read_bytes() == b"workflow-copy-of-nuclei"
+    assert not (returned / "labels/nuclei").exists()
+    assert (returned / "labels/cells/0/0.0.0.0").read_bytes() == b"new-cells"
 
 
 def test_materializes_legacy_shallow_manifest_without_component_records(

--- a/tests/unittests/test_result_zarr.py
+++ b/tests/unittests/test_result_zarr.py
@@ -513,3 +513,55 @@ def test_materializes_original_with_inherited_and_local_labels(tmp_path):
     assert (
         returned / "labels/nuclei/0/0.0.0.0"
     ).read_bytes() == b"workflow-copy-of-nuclei"
+
+
+def test_materializes_legacy_shallow_manifest_without_component_records(
+    tmp_path,
+):
+    import_root = tmp_path / "data"
+    group_root = import_root / "Project A"
+    canonical = group_root / ".processed/Image-1.ome.zarr"
+    returned = import_root / "results/result.zarr"
+    _make_image(canonical)
+    _make_image(returned, labels=("cells",))
+    label_chunk = returned / "labels/cells/0/0.0.0.0"
+    label_chunk.write_bytes(b"legacy-cells")
+    decision = evaluate_returned_zarr(
+        returned,
+        _manifest(_input(0, "result.zarr")),
+        identity_provider=IdentityProvider(_identity()),
+    )
+    normalize_returned_zarr(
+        decision,
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    )
+    manifest_path = returned / ".biomero-shallow.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["images"][0].pop("labelComponents")
+    _write_json(manifest_path, manifest)
+    roots = {
+        "import-mount-data": import_root,
+        "group-0-data": group_root,
+    }
+    registration = resolve_shallow_registration(
+        returned / "labels/cells",
+        storage_roots=roots,
+        import_mount_path=import_root,
+    )
+    destination = tmp_path / "full.zarr"
+
+    result = materialize_shallow_zarr(
+        registration.reference,
+        destination,
+        roots,
+        identity_provider=IdentityProvider(_identity()),
+    )
+
+    assert (
+        destination / "labels/cells/0/0.0.0.0"
+    ).read_bytes() == b"legacy-cells"
+    assert result.labels[0].source == ManagedZarrNode(
+        storage_root="import-mount-data",
+        relative_path="results/result.zarr",
+        node_path="labels/cells",
+    )

--- a/tests/unittests/test_result_zarr.py
+++ b/tests/unittests/test_result_zarr.py
@@ -755,6 +755,73 @@ def test_materializes_plate_label_projection_as_standalone_image(tmp_path):
     assert result.labels[0].source.node_path == label_path
 
 
+def test_materializes_whole_shallow_plate_with_all_image_labels(tmp_path):
+    import_root = tmp_path / "data"
+    group_root = import_root / "Project A"
+    canonical = group_root / ".processed/Plate-1.ome.zarr"
+    returned = import_root / "results/plate.zarr"
+    destination = tmp_path / "transfer/plate.zarr"
+    destination.parent.mkdir()
+    _make_plate(canonical)
+    _make_plate(returned, {
+        "A/1/0": ("cells",),
+        "B/1/0": ("cells",),
+    })
+    identities = {
+        "A/1/0": _identity("ISCC:IA", "A/1/0"),
+        "B/1/0": _identity("ISCC:IB", "B/1/0"),
+        "A/1/0/labels/cells": _identity(
+            "ISCC:IACELLS", "A/1/0/labels/cells", "label"
+        ),
+        "B/1/0/labels/cells": _identity(
+            "ISCC:IBCELLS", "B/1/0/labels/cells", "label"
+        ),
+    }
+    decision = evaluate_returned_zarr(
+        returned,
+        _manifest(_plate_input()),
+        identity_provider=NodeIdentityProvider(identities),
+    )
+    normalize_returned_zarr(
+        decision,
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    )
+    roots = {
+        "import-mount-data": import_root,
+        "group-0-data": group_root,
+    }
+    registration = resolve_shallow_registration(
+        returned,
+        storage_roots=roots,
+        import_mount_path=import_root,
+    )
+
+    result = materialize_shallow_zarr(
+        registration.reference,
+        destination,
+        roots,
+    )
+
+    assert json.loads((destination / ".zattrs").read_text(encoding="utf-8")) == {
+        "plate": {"wells": [{"path": "A/1"}, {"path": "B/1"}]},
+    }
+    for image_path in ("A/1/0", "B/1/0"):
+        assert (
+            destination / image_path / "0/0.0.0.0"
+        ).read_bytes() == b"image-pixels" * 2048
+        assert (
+            destination / image_path / "labels/cells/0/0.0.0.0"
+        ).read_bytes() == b"image-pixels" * 2048
+        assert json.loads((
+            destination / image_path / "labels/.zattrs"
+        ).read_text(encoding="utf-8")) == {"labels": ["cells"]}
+    assert {label.logical_node_path for label in result.labels} == {
+        "A/1/0/labels/cells",
+        "B/1/0/labels/cells",
+    }
+    assert all(label.source is not None for label in result.labels)
+
+
 def test_materializes_legacy_shallow_manifest_without_component_records(
     tmp_path,
 ):

--- a/tests/unittests/test_result_zarr.py
+++ b/tests/unittests/test_result_zarr.py
@@ -273,6 +273,7 @@ def test_normalizes_plate_images_and_retains_image_level_label(tmp_path):
     normalized = normalize_returned_zarr(
         decision,
         "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        measure_bytes=True,
     )
 
     assert decision.eligible
@@ -493,6 +494,7 @@ def test_normalization_transaction_keeps_labels_and_omits_image_chunks(
     normalized = normalize_returned_zarr(
         decision,
         "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        measure_bytes=True,
     )
 
     assert not (root / "0").exists()
@@ -513,10 +515,22 @@ def test_normalization_transaction_keeps_labels_and_omits_image_chunks(
     assert not list(tmp_path.glob(".result.zarr.biomero-*"))
 
 
-def test_normalization_restores_full_store_when_commit_rename_fails(tmp_path):
+def test_normalization_restores_full_store_when_array_move_fails(tmp_path):
     root = tmp_path / "result.zarr"
     _make_image(root, labels=("cells",))
     original_chunk = root / "0/0.0.0.0"
+    attrs_path = root / ".zattrs"
+    attrs = json.loads(attrs_path.read_text(encoding="utf-8"))
+    attrs["multiscales"][0]["datasets"].append({"path": "1"})
+    _write_json(attrs_path, attrs)
+    _write_json(root / "1/.zarray", {
+        "zarr_format": 2,
+        "shape": [1, 1, 4, 4],
+        "chunks": [1, 1, 4, 4],
+        "dtype": "<u2",
+    })
+    second_chunk = root / "1/0.0.0.0"
+    second_chunk.write_bytes(b"second-image-pyramid")
     decision = evaluate_returned_zarr(
         root,
         _manifest(_input(0, "result.zarr")),
@@ -543,7 +557,41 @@ def test_normalization_restores_full_store_when_commit_rename_fails(tmp_path):
         raise AssertionError("normalization unexpectedly succeeded")
 
     assert original_chunk.read_bytes() == b"image-pixels" * 2048
+    assert second_chunk.read_bytes() == b"second-image-pyramid"
+    assert json.loads(attrs_path.read_text(encoding="utf-8")) == attrs
     assert not (root / ".biomero-shallow.json").exists()
+    assert not list(tmp_path.glob(".result.zarr.biomero-*"))
+
+
+def test_normalization_moves_arrays_without_copying_retained_tree(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "result.zarr"
+    _make_image(root, labels=("cells",))
+    decision = evaluate_returned_zarr(
+        root,
+        _manifest(_input(0, "result.zarr")),
+        identity_provider=IdentityProvider(_identity()),
+    )
+
+    def fail_copytree(*args, **kwargs):
+        raise AssertionError("normalization must not copy the retained tree")
+
+    monkeypatch.setattr(
+        "biomero_importer.utils.result_zarr.shutil.copytree",
+        fail_copytree,
+    )
+
+    normalized = normalize_returned_zarr(
+        decision,
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    )
+
+    assert normalized.bytes_before is None
+    assert normalized.bytes_after is None
+    assert not (root / "0").exists()
+    assert (root / "labels/cells/0/0.0.0.0").exists()
 
 
 def test_resolves_primary_and_label_registration_views(tmp_path):

--- a/tests/unittests/test_result_zarr.py
+++ b/tests/unittests/test_result_zarr.py
@@ -1,0 +1,212 @@
+import json
+from pathlib import Path
+from uuid import UUID
+
+from biomero_schema.zarr import (
+    CanonicalInput,
+    CanonicalInputManifest,
+    CanonicalZarrSource,
+    PixelIdentity,
+)
+
+from biomero_importer.utils.result_zarr import (
+    discover_ngff_nodes,
+    evaluate_returned_zarr,
+    find_returned_zarr_stores,
+)
+
+
+def _write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _make_image(root: Path, node_path=".", labels=()) -> None:
+    node = root if node_path == "." else root / node_path
+    _write_json(node / ".zgroup", {"zarr_format": 2})
+    _write_json(node / ".zattrs", {
+        "multiscales": [{
+            "version": "0.4",
+            "axes": [
+                {"name": "t"},
+                {"name": "c"},
+                {"name": "y"},
+                {"name": "x"},
+            ],
+            "datasets": [{"path": "0"}],
+        }],
+    })
+    _write_json(node / "0" / ".zarray", {
+        "zarr_format": 2,
+        "shape": [1, 1, 8, 8],
+        "chunks": [1, 1, 8, 8],
+        "dtype": "<u2",
+    })
+    if labels:
+        _write_json(node / "labels" / ".zgroup", {"zarr_format": 2})
+        _write_json(node / "labels" / ".zattrs", {"labels": list(labels)})
+        for label in labels:
+            _make_image(root, f"{node_path}/labels/{label}".replace("./", ""))
+
+
+def _identity(instance="ISCC:IINSTANCE", node_path=".") -> PixelIdentity:
+    return PixelIdentity(
+        node_path=node_path,
+        role="image",
+        iscc_code="ISCC:KSUM",
+        data_code="ISCC:GDATA",
+        instance_code=instance,
+        tool_version="0.1.0",
+        imagewalk_revision="iscc-bio/0.1.0@revision",
+        shape=(1, 1, 8, 8),
+        dtype="uint16",
+        axes=("t", "c", "y", "x"),
+    )
+
+
+def _manifest(*items) -> CanonicalInputManifest:
+    return CanonicalInputManifest(
+        workflow_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        export_task_id=UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+        inputs=tuple(items),
+    )
+
+
+def _input(ordinal, artifact=None, instance="ISCC:IINSTANCE") -> CanonicalInput:
+    identity = _identity(instance)
+    return CanonicalInput(
+        ordinal=ordinal,
+        selected_object_type="Image",
+        selected_object_id=ordinal + 1,
+        transfer_artifact=artifact,
+        source=CanonicalZarrSource(
+            storage_root="group-0-data",
+            relative_path=f".processed/Image-{ordinal + 1}.ome.zarr",
+            node_path=".",
+            source_object_type="Image",
+            source_object_id=ordinal + 1,
+            source_generation=1,
+            interchange_profile="ngff-0.4-zarr-v2",
+            pixel_identity=identity,
+            pixel_identity_origin="omero-pixels",
+            canonical_pixel_verified=True,
+        ),
+    )
+
+
+class IdentityProvider:
+    def __init__(self, identity):
+        self.identity = identity
+        self.calls = []
+
+    def generate(self, root, **kwargs):
+        self.calls.append((Path(root), kwargs))
+        return self.identity.model_copy(update={
+            "node_path": kwargs["node_path"],
+            "role": kwargs["role"],
+        })
+
+
+def test_discovers_image_and_declared_labels(tmp_path):
+    root = tmp_path / "result.zarr"
+    _make_image(root, labels=("cells", "nuclei"))
+
+    nodes = discover_ngff_nodes(root)
+
+    assert [(node.node_path, node.role) for node in nodes] == [
+        (".", "image"),
+        ("labels/cells", "label"),
+        ("labels/nuclei", "label"),
+    ]
+
+
+def test_discovers_plate_image_level_labels(tmp_path):
+    root = tmp_path / "plate.zarr"
+    _write_json(root / ".zattrs", {"plate": {"wells": [{"path": "A/1"}]}})
+    _write_json(root / "A/1/.zattrs", {"well": {"images": [{"path": "0"}]}})
+    _make_image(root, "A/1/0", labels=("cells",))
+
+    nodes = discover_ngff_nodes(root)
+
+    assert [(node.node_path, node.role) for node in nodes] == [
+        ("A/1/0", "image"),
+        ("A/1/0/labels/cells", "label"),
+    ]
+
+
+def test_transfer_artifact_disambiguates_duplicate_input_identities(tmp_path):
+    root = tmp_path / "second.zarr"
+    _make_image(root, labels=("cells",))
+    provider = IdentityProvider(_identity())
+    manifest = _manifest(
+        _input(0, "first.zarr"),
+        _input(1, "second.zarr"),
+    )
+
+    decision = evaluate_returned_zarr(
+        root,
+        manifest,
+        identity_provider=provider,
+    )
+
+    assert decision.eligible
+    assert decision.reason == "input-image-unchanged"
+    assert decision.matched_inputs[0].ordinal == 1
+
+
+def test_legacy_duplicate_identities_are_ambiguous(tmp_path):
+    root = tmp_path / "result.zarr"
+    _make_image(root, labels=("cells",))
+    manifest = _manifest(_input(0), _input(1))
+
+    decision = evaluate_returned_zarr(
+        root,
+        manifest,
+        identity_provider=IdentityProvider(_identity()),
+    )
+
+    assert not decision.eligible
+    assert decision.reason == "ambiguous-input-identity"
+
+
+def test_changed_pixels_keep_full_even_when_artifact_matches(tmp_path):
+    root = tmp_path / "result.zarr"
+    _make_image(root, labels=("cells",))
+    manifest = _manifest(_input(0, "result.zarr"))
+
+    decision = evaluate_returned_zarr(
+        root,
+        manifest,
+        identity_provider=IdentityProvider(_identity("ISCC:ICHANGED")),
+    )
+
+    assert not decision.eligible
+    assert decision.reason == "pixels-changed"
+
+
+def test_result_without_labels_is_not_eligible(tmp_path):
+    root = tmp_path / "result.zarr"
+    _make_image(root)
+    provider = IdentityProvider(_identity())
+
+    decision = evaluate_returned_zarr(
+        root,
+        _manifest(_input(0, "result.zarr")),
+        identity_provider=provider,
+    )
+
+    assert not decision.eligible
+    assert decision.reason == "no-label-nodes"
+    assert provider.calls == []
+
+
+def test_store_finder_prunes_nested_label_zarrs(tmp_path):
+    outer = tmp_path / "nested" / "result.ome.zarr"
+    nested = outer / "labels" / "cells.zarr"
+    nested.mkdir(parents=True)
+    (tmp_path / "second.zarr").mkdir()
+
+    assert find_returned_zarr_stores(tmp_path) == (
+        tmp_path / "second.zarr",
+        outer,
+    )

--- a/tests/unittests/test_result_zarr.py
+++ b/tests/unittests/test_result_zarr.py
@@ -5,6 +5,8 @@ from uuid import UUID
 from biomero_schema.zarr import (
     CanonicalInput,
     CanonicalInputManifest,
+    CanonicalPlateImage,
+    CanonicalPlateSource,
     CanonicalZarrSource,
     ManagedZarrNode,
     PixelIdentity,
@@ -53,6 +55,21 @@ def _make_image(root: Path, node_path=".", labels=()) -> None:
         _write_json(node / "labels" / ".zattrs", {"labels": list(labels)})
         for label in labels:
             _make_image(root, f"{node_path}/labels/{label}".replace("./", ""))
+
+
+def _make_plate(root: Path, labels_by_image=None) -> None:
+    labels_by_image = labels_by_image or {}
+    _write_json(root / ".zgroup", {"zarr_format": 2})
+    _write_json(root / ".zattrs", {
+        "plate": {"wells": [{"path": "A/1"}, {"path": "B/1"}]},
+    })
+    for well in ("A/1", "B/1"):
+        _write_json(
+            root / well / ".zattrs",
+            {"well": {"images": [{"path": "0"}]}},
+        )
+        image_path = f"{well}/0"
+        _make_image(root, image_path, labels_by_image.get(image_path, ()))
 
 
 def _identity(
@@ -110,6 +127,47 @@ def _input(
     )
 
 
+def _plate_input(artifact="plate.zarr", labels_by_image=None) -> CanonicalInput:
+    labels_by_image = labels_by_image or {}
+    relative_path = ".processed/Plate-1.ome.zarr"
+    images = []
+    for image_path, instance in (
+        ("A/1/0", "ISCC:IA"),
+        ("B/1/0", "ISCC:IB"),
+    ):
+        source = CanonicalZarrSource(
+            storage_root="group-0-data",
+            relative_path=relative_path,
+            node_path=image_path,
+            source_object_type="Plate",
+            source_object_id=1,
+            source_generation=1,
+            interchange_profile="ngff-0.4-zarr-v2",
+            pixel_identity=_identity(instance, image_path),
+            pixel_identity_origin="canonical-bootstrap",
+            canonical_pixel_verified=True,
+        )
+        images.append(CanonicalPlateImage(
+            image_node_path=image_path,
+            source=source,
+            labels=tuple(labels_by_image.get(image_path, ())),
+        ))
+    return CanonicalInput(
+        ordinal=0,
+        selected_object_type="Plate",
+        selected_object_id=1,
+        transfer_artifact=artifact,
+        plate_source=CanonicalPlateSource(
+            storage_root="group-0-data",
+            relative_path=relative_path,
+            source_object_id=1,
+            source_generation=1,
+            interchange_profile="ngff-0.4-zarr-v2",
+            images=tuple(images),
+        ),
+    )
+
+
 class IdentityProvider:
     def __init__(self, identity):
         self.identity = identity
@@ -158,6 +216,77 @@ def test_discovers_plate_image_level_labels(tmp_path):
         ("A/1/0", "image"),
         ("A/1/0/labels/cells", "label"),
     ]
+
+
+def test_unchanged_plate_without_labels_is_a_passthrough(tmp_path):
+    root = tmp_path / "plate.zarr"
+    _make_plate(root)
+    provider = NodeIdentityProvider({
+        "A/1/0": _identity("ISCC:IA", "A/1/0"),
+        "B/1/0": _identity("ISCC:IB", "B/1/0"),
+    })
+
+    decision = evaluate_returned_zarr(
+        root,
+        _manifest(_plate_input()),
+        identity_provider=provider,
+    )
+
+    assert decision.unchanged_passthrough
+    assert decision.reason == "input-plate-unchanged-no-labels"
+    assert len(decision.image_identities) == 2
+
+
+def test_changed_plate_image_keeps_full_result(tmp_path):
+    root = tmp_path / "plate.zarr"
+    _make_plate(root, {"A/1/0": ("cells",)})
+    provider = NodeIdentityProvider({
+        "A/1/0": _identity("ISCC:IA", "A/1/0"),
+        "B/1/0": _identity("ISCC:ICHANGED", "B/1/0"),
+    })
+
+    decision = evaluate_returned_zarr(
+        root,
+        _manifest(_plate_input()),
+        identity_provider=provider,
+    )
+
+    assert decision.outcome == "keep-full"
+    assert decision.reason == "pixels-changed"
+
+
+def test_normalizes_plate_images_and_retains_image_level_label(tmp_path):
+    root = tmp_path / "plate.zarr"
+    _make_plate(root, {"A/1/0": ("cells",)})
+    label_path = "A/1/0/labels/cells"
+    provider = NodeIdentityProvider({
+        "A/1/0": _identity("ISCC:IA", "A/1/0"),
+        "B/1/0": _identity("ISCC:IB", "B/1/0"),
+        label_path: _identity("ISCC:ICELLS", label_path, "label"),
+    })
+    decision = evaluate_returned_zarr(
+        root,
+        _manifest(_plate_input()),
+        identity_provider=provider,
+    )
+
+    normalized = normalize_returned_zarr(
+        decision,
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    )
+
+    assert decision.eligible
+    assert decision.reason == "input-plate-unchanged"
+    assert not (root / "A/1/0/0").exists()
+    assert not (root / "B/1/0/0").exists()
+    assert (root / label_path).is_dir()
+    assert len(normalized.collection.images) == 2
+    images = {
+        image.image_node_path: image
+        for image in normalized.collection.images
+    }
+    assert images["A/1/0"].label_node_paths == (label_path,)
+    assert images["B/1/0"].label_node_paths == ()
 
 
 def test_transfer_artifact_disambiguates_duplicate_input_identities(tmp_path):
@@ -512,6 +641,55 @@ def test_materializes_original_with_inherited_and_local_labels(tmp_path):
     assert all(label.source is not None for label in result.labels)
     assert not (returned / "labels/nuclei").exists()
     assert (returned / "labels/cells/0/0.0.0.0").read_bytes() == b"new-cells"
+
+
+def test_materializes_plate_label_projection_as_standalone_image(tmp_path):
+    import_root = tmp_path / "data"
+    group_root = import_root / "Project A"
+    canonical = group_root / ".processed/Plate-1.ome.zarr"
+    returned = import_root / "results/plate.zarr"
+    _make_plate(canonical)
+    _make_plate(returned, {"A/1/0": ("cells",)})
+    label_path = "A/1/0/labels/cells"
+    provider = NodeIdentityProvider({
+        "A/1/0": _identity("ISCC:IA", "A/1/0"),
+        "B/1/0": _identity("ISCC:IB", "B/1/0"),
+        label_path: _identity("ISCC:ICELLS", label_path, "label"),
+    })
+    decision = evaluate_returned_zarr(
+        returned,
+        _manifest(_plate_input()),
+        identity_provider=provider,
+    )
+    normalize_returned_zarr(
+        decision,
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    )
+    roots = {
+        "import-mount-data": import_root,
+        "group-0-data": group_root,
+    }
+    registration = resolve_shallow_registration(
+        returned / label_path,
+        storage_roots=roots,
+        import_mount_path=import_root,
+    )
+    destination = tmp_path / "transfer/image.zarr"
+    destination.parent.mkdir()
+
+    result = materialize_shallow_zarr(
+        registration.reference,
+        destination,
+        roots,
+    )
+
+    assert (destination / "0/0.0.0.0").read_bytes() == b"image-pixels" * 2048
+    assert (
+        destination / "labels/cells/0/0.0.0.0"
+    ).read_bytes() == b"image-pixels" * 2048
+    assert discover_ngff_nodes(destination)[0].node_path == "."
+    assert result.labels[0].logical_node_path == "labels/cells"
+    assert result.labels[0].source.node_path == label_path
 
 
 def test_materializes_legacy_shallow_manifest_without_component_records(


### PR DESCRIPTION
Add support for shallow storing workflow results ([RFC-8 style](https://ngff.openmicroscopy.org/rfc/8/index.html#shallow-copies-of-images-with-segmentations)). 

We would have a canonical Zarr stored already (every workflow works w/ Zarr, even if later converted to Tiff) and not need a duplicate of its base image pixels if they are similar. 

We would check base image equality using [iscc-bio](https://github.com/bio-codes/iscc-bio), since we don't actually know if the wf changed the image - perhaps they did some projection, deconvolution, or other operation on the base image - instead of creating labels.

 